### PR TITLE
remove unnecessary line in builder function

### DIFF
--- a/cvx/simulator/builder.py
+++ b/cvx/simulator/builder.py
@@ -165,7 +165,6 @@ def builder(prices, weights=None, initial_cash=1e6, trading_cost_model=None):
 
     stocks = pd.DataFrame(index=prices.index, columns=prices.columns, data=0.0, dtype=float)
 
-    trading_cost_model = trading_cost_model
     builder = _Builder(stocks=stocks, prices=prices.ffill(), initial_cash=float(initial_cash),
                     trading_cost_model=trading_cost_model)
 


### PR DESCRIPTION
hey all,

thanks for putting this together, great to see open source efforts on backtests! this is a problem i'm quite interested on myself!

this PR just fix a minor redundancy in the ``builder`` function.

tests pass locally with ``poetry run pytest``.