### PR TITLE
initial_cash -> initial_aum

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ import pandas as pd
 from cvx.simulator import Builder
 
 prices = pd.read_csv("prices.csv", index_col=0, parse_dates=True, header=0)
-b = Builder(prices=prices, initial_cash=1e6)
+b = Builder(prices=prices, initial_aum=1e6)
 ```
 
 Prices have to be valid, there may be NaNs only at the beginning and the end of


### PR DESCRIPTION
Fixed minor typo in readme file. initial_cash has been replaced with initial_aum.