### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,5 +1,7 @@
 # Workflow for code quality checks and dependency analysis
 name: pre-commit
+permissions:
+  contents: read
 
 # Trigger workflow on push events
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/cvxgrp/simulator/security/code-scanning/13](https://github.com/cvxgrp/simulator/security/code-scanning/13)

To fix the issue, we will add a `permissions` block at the root level of the workflow to apply to all jobs. Based on the provided workflow, the actions appear to perform dependency analysis and run pre-commit hooks, which likely only require read access to the repository contents. Therefore, we will set `contents: read` as the minimal permission. If any of the actions require additional permissions, they can be added later after further analysis.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
