### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 # Continuous Integration workflow to ensure code quality and compatibility
 name: "CI"
+permissions:
+  contents: read
 
 # Trigger workflow on push events
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/cvxgrp/simulator/security/code-scanning/11](https://github.com/cvxgrp/simulator/security/code-scanning/11)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Based on the actions used in the workflow, the `contents: read` permission is sufficient, as the workflow appears to only read repository contents and run tests. No write permissions are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
