### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,6 +1,10 @@
 # Workflow for building documentation and running tests
 name: "book"
 
+# Set default permissions for all jobs
+permissions:
+  contents: read
+
 # Trigger workflow on push events
 on:
 - push


### PR DESCRIPTION
Potential fix for [https://github.com/cvxgrp/simulator/security/code-scanning/12](https://github.com/cvxgrp/simulator/security/code-scanning/12)

To fix the issue, we will add a `permissions` block to the root of the workflow to define default permissions for all jobs. This block will specify `contents: read`, which is sufficient for most CI tasks. For jobs requiring additional permissions, such as the `book` job, we will retain or add job-specific `permissions` blocks. This ensures that each job has only the permissions it needs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
