### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -9,6 +9,8 @@ jobs:
   # Process marimo notebooks
   marimo:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       # Set up Python environment with dependencies
       - name: "Build the virtual environment for ${{ github.repository }}"
@@ -20,6 +22,8 @@ jobs:
   # Generate API documentation using pdoc
   pdoc:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       # Set up Python environment with dependencies
       - name: "Build the virtual environment for ${{ github.repository }}"
@@ -33,6 +37,8 @@ jobs:
   # Run tests with coverage reporting
   test:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       # Set up Python environment with dependencies
       - name: "Build the virtual environment for ${{ github.repository }}"
@@ -47,6 +53,8 @@ jobs:
   # Process Jupyter notebooks
   jupyter:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       # Set up Python environment with dependencies
       - name: "Build the virtual environment for ${{ github.repository }}"


### PR DESCRIPTION
Potential fix for [https://github.com/cvxgrp/simulator/security/code-scanning/14](https://github.com/cvxgrp/simulator/security/code-scanning/14)

To fix the issue, we will add a `permissions` block to each job (`marimo`, `pdoc`, `test`, and `jupyter`) in the workflow. These blocks will specify the minimal permissions required for each job. Based on the provided workflow, most jobs likely only need `contents: read` permissions, as they do not appear to perform any write operations. The `book` job already has explicit permissions defined, so no changes are needed there.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
