### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
 
   # Job to build the package with the new version
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: tagging  # Depends on the tagging job to get the new version
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/cvxgrp/simulator/security/code-scanning/15](https://github.com/cvxgrp/simulator/security/code-scanning/15)

To fix the issue, we need to add an explicit `permissions` block to the `build` job in the workflow file. Based on the job's functionality, it only requires read access to the repository contents. Therefore, the `permissions` block should be set to `contents: read`. This change ensures that the job does not inherit unnecessary write permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
