### PR TITLE
updates

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       # Step: Set up the virtual environment
       - name: "Build the virtual environment"
-        uses: tschm/cradle/actions/environment@v0.1.71
+        uses: tschm/cradle/actions/environment@v0.1.72
 
       - name: "Run the marimo notebooks"
         uses: tschm/cradle/actions/marimo@main
@@ -33,10 +33,10 @@ jobs:
     steps:
       # Set up Python environment with dependencies
       - name: "Build the virtual environment for ${{ github.repository }}"
-        uses: tschm/cradle/actions/environment@v0.1.71
+        uses: tschm/cradle/actions/environment@v0.1.72
 
       # Generate API documentation for the source code
-      - uses: tschm/cradle/actions/pdoc@v0.1.71
+      - uses: tschm/cradle/actions/pdoc@v0.1.72
         with:
           source-folder: 'src/cvxsimulator'
 
@@ -48,10 +48,10 @@ jobs:
     steps:
       # Set up Python environment with dependencies
       - name: "Build the virtual environment for ${{ github.repository }}"
-        uses: tschm/cradle/actions/environment@v0.1.71
+        uses: tschm/cradle/actions/environment@v0.1.72
 
       # Run tests and generate coverage report
-      - uses: tschm/cradle/actions/coverage@v0.1.71
+      - uses: tschm/cradle/actions/coverage@v0.1.72
         with:
           tests-folder: 'src/tests'
           source-folder: 'src/cvxsimulator'
@@ -64,10 +64,10 @@ jobs:
     steps:
       # Set up Python environment with dependencies
       - name: "Build the virtual environment for ${{ github.repository }}"
-        uses: tschm/cradle/actions/environment@v0.1.71
+        uses: tschm/cradle/actions/environment@v0.1.72
 
       # Run Jupyter notebook processing
-      - uses: tschm/cradle/actions/jupyter@v0.1.71
+      - uses: tschm/cradle/actions/jupyter@v0.1.72
 
   book:
     runs-on: "ubuntu-latest"
@@ -86,4 +86,4 @@ jobs:
       # Step: Upload the generated documentation book
       # Skipped when running locally with 'act' to prevent accidental deployments
       - name: Upload the book
-        uses: tschm/cradle/actions/book@v0.1.71
+        uses: tschm/cradle/actions/book@v0.1.72

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,11 @@ jobs:
     steps:
       # Set up Python environment with dependencies for the specified version
       - name: "Build the virtual environment for ${{ github.repository }}"
-        uses: tschm/cradle/actions/environment@v0.1.71
+        uses: tschm/cradle/actions/environment@v0.1.72
         with:
           python-version: ${{ matrix.python-version }}
 
       # Run the test suite
-      - uses: tschm/cradle/actions/test@v0.1.71
+      - uses: tschm/cradle/actions/test@v0.1.72
         with:
           tests-folder: 'src/tests'

--- a/.github/workflows/marimo.yml
+++ b/.github/workflows/marimo.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: "Build the virtual environment for ${{ github.repository }}"
-        uses: tschm/cradle/actions/environment@v0.1.71
+        uses: tschm/cradle/actions/environment@v0.1.72
 
       - name: List notebooks
         id: set-notebooks
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: "Build the virtual environment for ${{ github.repository }}"
-        uses: tschm/cradle/actions/environment@v0.1.71
+        uses: tschm/cradle/actions/environment@v0.1.72
 
       - name: Run notebook
         run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # Set up Python environment with dependencies
       - name: "Build the virtual environment for ${{ github.repository }}"
-        uses: tschm/cradle/actions/environment@v0.1.71
+        uses: tschm/cradle/actions/environment@v0.1.72
 
       - name: Run deptry
         run : |
@@ -29,4 +29,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Run all configured pre-commit hooks
-      - uses: tschm/cradle/actions/pre-commit@v0.1.71
+      - uses: tschm/cradle/actions/pre-commit@v0.1.72

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Generate Tag
         id: tag_step
-        uses: tschm/cradle/actions/tag@v0.1.71  # Use the tag action to generate a new version tag
+        uses: tschm/cradle/actions/tag@v0.1.72  # Use the tag action to generate a new version tag
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}  # GitHub token for authentication
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,6 @@ repos:
       - id: validate-pyproject
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.32.0
+    rev: v1.33.1
     hooks:
       - id: typos

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.11.11'
+    rev: 'v0.11.13'
 
     hooks:
       - id: ruff


### PR DESCRIPTION
This pull request updates various GitHub Actions workflows and the `.pre-commit-config.yaml` file to use newer versions of dependencies. The most important changes include upgrading the `tschm/cradle` actions across multiple workflows and updating pre-commit hooks for `ruff` and `typos`.

### Pre-commit Hook Updates:
* Upgraded `ruff-pre-commit` hook from `v0.11.11` to `v0.11.13` in `.pre-commit-config.yaml`.
* Upgraded `typos` hook from `v1.32.0` to `v1.33.1` in `.pre-commit-config.yaml`.