### PR TITLE
Do not publish book on a fork

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -70,6 +70,8 @@ jobs:
       - uses: tschm/cradle/actions/jupyter@v0.1.72
 
   book:
+    # don't try to publish the book if you are on a fork
+    if: github.event.repository.fork == false
     runs-on: "ubuntu-latest"
     # This job depends on the completion of test, pdoc, and jupyter jobs
     needs: [test, pdoc, jupyter, marimo]


### PR DESCRIPTION
This pull request includes a small but important update to the `.github/workflows/book.yml` file. The change ensures that the book publishing workflow will not run on forked repositories.

* [`.github/workflows/book.yml`](diffhunk://#diff-b8e1b9f11d0148dab38c89b9eaf5aa56792726c6cead6bf9e359f53faa0eedb3R73-R74): Added a conditional check to prevent the `book` job from running if the repository is a fork.Don't publish book on fork