### PR TITLE
feat: add ClusterFuzzLite fuzzing scaffold for cvx.simulator

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,9 @@
+# ClusterFuzzLite build image for cvx.simulator.
+# Uses the OSS-Fuzz Python base image, which provides Atheris and the
+# compile_python_fuzzer helper.
+# Pinned by SHA256 so the build image only changes through reviewed updates.
+FROM gcr.io/oss-fuzz-base/base-builder-python@sha256:99c714c91ec30778a3ce3ae5b37491a81fc043808bc8f2955159c2f608f80116
+
+COPY . $SRC
+WORKDIR $SRC
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+# ClusterFuzzLite build script — installs cvx.simulator and compiles each Python
+# harness in tests/fuzz/ via OSS-Fuzz's compile_python_fuzzer helper.
+
+cd "$SRC"
+
+# Pin pip so the build environment is reproducible and only changes through a
+# reviewed bump (the same rationale as the SHA-pinned base image).
+pip3 install --upgrade "pip==24.3.1"
+
+# Install the package and its runtime dependencies so PyInstaller can discover
+# and bundle cvx.simulator into each frozen fuzzer binary.
+pip3 install .
+
+# PyInstaller does not discover numpy's C-extension submodules on its own, so
+# the frozen fuzzer crashes at runtime with
+# "No module named 'numpy._core._exceptions'". --collect-all pulls in every
+# numpy submodule, data file and shared library.
+for fuzzer in tests/fuzz/fuzz_*.py; do
+  compile_python_fuzzer "$fuzzer" --collect-all numpy --collect-all pandas
+done

--- a/tests/fuzz/fuzz_interpolation.py
+++ b/tests/fuzz/fuzz_interpolation.py
@@ -1,0 +1,71 @@
+"""Fuzz the cvx.simulator polars interpolation helpers against arbitrary series.
+
+``interpolate_pl``/``interpolate_df_pl`` interior-forward-fill polars series and
+frames, and ``valid_pl``/``valid_df_pl`` check that the non-null span is
+contiguous. None should crash with an unexpected exception on adversarial input
+(empty, all-null, NaN/inf) — they should return a result or raise a documented
+error. This harness exercises that contract with coverage-guided input.
+
+Run locally:
+    pip install atheris numpy pandas polars
+    python tests/fuzz/fuzz_interpolation.py -atheris_runs=20000
+
+Run in ClusterFuzzLite: this file is built by .clusterfuzzlite/build.sh.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+
+import atheris
+
+# Pre-import the heavy native dependencies OUTSIDE the instrumentation block.
+# Atheris's import hook miscompiles parts of polars' Python machinery, so we let
+# these load uninstrumented and instrument only the first-party package. The
+# cvx.simulator package __init__ pulls in pandas/polars (and jquantstats), so
+# they must be cached uninstrumented beforehand.
+import numpy as np  # noqa: F401  # pre-imported uninstrumented
+import pandas as pd  # noqa: F401  # pre-imported uninstrumented
+import polars as pl
+
+with atheris.instrument_imports():
+    from cvx.simulator.utils.interpolation import (
+        interpolate_df_pl,
+        interpolate_pl,
+        valid_df_pl,
+        valid_pl,
+    )
+
+_ALLOWED = (ValueError, TypeError, pl.exceptions.PolarsError)
+
+
+def _series(fdp: atheris.FuzzedDataProvider, name: str, n: int) -> pl.Series:
+    """Build a nullable float polars Series from fuzzed bytes."""
+    return pl.Series(name, [None if fdp.ConsumeBool() else fdp.ConsumeFloat() for _ in range(n)])
+
+
+def test_one_input(data: bytes) -> None:
+    """Exercise the polars interpolation helpers with a fuzzed series and frame."""
+    fdp = atheris.FuzzedDataProvider(data)
+    n = fdp.ConsumeIntInRange(0, 24)
+
+    series = _series(fdp, "v", n)
+    for fn in (valid_pl, interpolate_pl):
+        with contextlib.suppress(_ALLOWED):
+            fn(series)
+
+    frame = pl.DataFrame({"a": _series(fdp, "a", n), "b": _series(fdp, "b", n)})
+    for fn in (valid_df_pl, interpolate_df_pl):
+        with contextlib.suppress(_ALLOWED):
+            fn(frame)
+
+
+def main() -> None:
+    """Run the Atheris fuzz loop."""
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Opt-in **ClusterFuzzLite** scaffold so the existing `rhiza_fuzzing.yml` runs.
- `.clusterfuzzlite/Dockerfile` + `build.sh` (`--collect-all numpy/pandas`)
- `tests/fuzz/fuzz_interpolation.py` — fuzzes the polars helpers `interpolate_pl`/`valid_pl`/`interpolate_df_pl`/`valid_df_pl`. Native deps pre-imported outside `instrument_imports()` (atheris corrupts instrumented polars).

## Test plan
- [x] Build verified against the OSS-Fuzz `base-builder-python` image (interpolation module + polars/pandas bundled)
- [ ] Runtime fuzz loop on CI (polars SIGILLs under local x86-on-arm64 emulation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
