### PR TITLE
Chore: sync Rhiza template v0.19.6 → v0.19.9

### DIFF
--- a/.claude/commands/rhiza_quality.md
+++ b/.claude/commands/rhiza_quality.md
@@ -17,6 +17,13 @@ failures surface before the slow test suite — and collect results:
 
 Guidelines:
 
+- Run each gate as a single, bare `make <target>` command — one Bash call per
+  gate. Do **not** pipe (`| tee`, `| tail`), redirect (`2>&1 >`), chain
+  (`make fmt && make typecheck`), or prefix with `cd`. Bare `make <target>`
+  invocations match the allow-listed `Bash(make *)` rule and run without a
+  permission prompt; compound or piped commands do not and will prompt on every
+  gate. Read the full output directly from each call rather than capturing it to
+  a file.
 - Run all gates even after an early failure, so the full picture is visible
   rather than stopping at the first red.
 - If something fails, show the relevant output, diagnose the root cause, and

--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v0.19.6
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v0.19.9
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.19.6
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.19.9
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.19.6
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.19.9
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.19.6
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.19.9
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v0.19.6
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v0.19.9
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.19.6
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.19.9
     secrets: inherit

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v0.19.6
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v0.19.9
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -221,7 +221,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.19.6
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.19.9
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v0.19.6
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v0.19.9
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_sync.yml
+++ b/.github/workflows/rhiza_sync.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   sync:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.19.6
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.19.9
     with:
       direct: ${{ github.event_name == 'push' }}
       create-pr: ${{ github.event_name != 'push' && (github.event_name == 'schedule' || inputs.create-pr == true) }}

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.19.6
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.19.9
     secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,7 +76,7 @@ repos:
       - id: betterleaks
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.24
+    rev: 0.11.25
     hooks:
       - id: uv-lock
 

--- a/.rhiza/make.d/quality.mk
+++ b/.rhiza/make.d/quality.mk
@@ -14,7 +14,11 @@ all: fmt deptry test docs-coverage security license typecheck rhiza-test ## run 
 # contributes the folders it owns to DEPTRY_FOLDERS (and any per-folder ignores
 # to DEPTRY_IGNORE), so this core target never needs to know which bundles are
 # present. Core itself contributes SOURCE_FOLDER when it exists; see e.g.
-# marimo.mk for a bundle that appends its own folder.
+# marimo.mk for a bundle that appends its own folder. Rhiza's own tooling and
+# test folders (.rhiza/utils, .rhiza/tests) are deliberately excluded: their
+# dependencies are declared inline via PEP 723 script metadata or shipped in
+# .rhiza/requirements/, not in the project's pyproject, so deptry (which
+# validates against pyproject) would only emit noise for them.
 DEPTRY_FOLDERS ?=
 DEPTRY_IGNORE ?=
 ifneq ($(wildcard $(SOURCE_FOLDER)),)
@@ -50,7 +54,7 @@ todos: ## search and report all TODO/FIXME/HACK comments in the codebase
 
 suppression-audit: ## scan codebase for inline suppressions and report (grade, detail, histogram)
 	@printf "${BLUE}[INFO] Running suppression audit...${RESET}\n"
-	@${UV_BIN} run python .rhiza/utils/suppression_audit.py
+	@${UV_BIN} run .rhiza/utils/suppression_audit.py
 
 semgrep: install ## run Semgrep static analysis
 	@printf "${BLUE}[INFO] Running Semgrep...${RESET}\n"

--- a/.rhiza/make.d/test.mk
+++ b/.rhiza/make.d/test.mk
@@ -4,7 +4,7 @@
 # executing performance benchmarks.
 
 # Declare phony targets (they don't produce files)
-.PHONY: test benchmark typecheck security docs-coverage hypothesis-test coverage-badge stress test-pyproject mutation
+.PHONY: test benchmark typecheck security docs-coverage hypothesis-test stress test-pyproject mutation
 
 # Default directory for tests
 TESTS_FOLDER := tests
@@ -98,7 +98,7 @@ PIP_AUDIT_ARGS ?=
 # 2. Runs bandit to find common security issues in Python source folders that exist.
 security: install ## run security scans (pip-audit and bandit)
 	@printf "${BLUE}[INFO] Running pip-audit for dependency vulnerabilities...${RESET}\n"
-	@${UV_BIN} run python .rhiza/utils/pip_audit_policy.py ${PIP_AUDIT_ARGS}
+	@${UV_BIN} run .rhiza/utils/pip_audit_policy.py ${PIP_AUDIT_ARGS}
 	@bandit_paths=""; \
 	if [ -d "${SOURCE_FOLDER}" ]; then \
 	  bandit_paths="${SOURCE_FOLDER}"; \

--- a/.rhiza/requirements/docs.txt
+++ b/.rhiza/requirements/docs.txt
@@ -2,3 +2,4 @@
 interrogate>=1.7.0
 mike>=2.2.0
 zensical>=0.0.33
+mkdocs-material>=9.0

--- a/.rhiza/requirements/tests.txt
+++ b/.rhiza/requirements/tests.txt
@@ -8,6 +8,7 @@ pytest-xdist>=3.0
 pytest-timeout>=2.0
 PyYAML>=6.0
 defusedxml>=0.7.0
+packaging>=24
 mutmut>=2.0,<3.0
 
 # For property-based testing

--- a/.rhiza/rhiza.mk
+++ b/.rhiza/rhiza.mk
@@ -180,9 +180,21 @@ summarise-sync: install-uv ## summarise differences created by sync with templat
 		${UVX_BIN} "rhiza==$(RHIZA_VERSION)" summarise .; \
 	fi
 
+# Minimum coverage percent for rhiza's own utilities (.rhiza/utils) when the
+# rhiza-test suite runs. Override per project, e.g.
+#   make rhiza-test RHIZA_COVERAGE_FAIL_UNDER=100
+RHIZA_COVERAGE_FAIL_UNDER ?= 90
+
 rhiza-test: install ## run rhiza's own tests (if any)
 	@if [ -d ".rhiza/tests" ]; then \
-		${UV_BIN} run pytest .rhiza/tests; \
+		if [ -d ".rhiza/utils" ]; then \
+			${UV_BIN} run pytest .rhiza/tests \
+				--cov=.rhiza/utils \
+				--cov-report=term-missing \
+				--cov-fail-under=$(RHIZA_COVERAGE_FAIL_UNDER); \
+		else \
+			${UV_BIN} run pytest .rhiza/tests; \
+		fi; \
 	else \
 		printf "${YELLOW}[WARN] No .rhiza/tests directory found, skipping rhiza-tests${RESET}\n"; \
 	fi

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: 1a17313aea5af3d15901a77b18f1bff91c7da3a7
+sha: ff7bd135efaaad8aadf01d41bb60dd8419c015ae
 repo: jebel-quant/rhiza
 host: github
-ref: v0.19.6
+ref: v0.19.9
 include: []
 exclude: []
 templates:
@@ -92,6 +92,8 @@ files:
 - .rhiza/tests/utils/test_suppression_audit.py
 - .rhiza/utils/pip_audit_policy.py
 - .rhiza/utils/suppression_audit.py
+- .rhiza/utils/suppression_parse.py
+- .rhiza/utils/suppression_report.py
 - LICENSE
 - Makefile
 - SECURITY.md
@@ -105,5 +107,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-06-27T04:30:15Z'
+synced_at: '2026-06-28T18:08:12Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 template-repository: "jebel-quant/rhiza"
-template-branch: "v0.19.6"
+template-branch: "v0.19.9"
 
 profiles:
   - github-project

--- a/.rhiza/tests/api/test_makefile_targets.py
+++ b/.rhiza/tests/api/test_makefile_targets.py
@@ -174,6 +174,56 @@ class TestMakefile:
         assert ".rhiza/utils" in out
         assert "No bandit scan folders found" in out
 
+    def test_benchmark_target_dry_run(self, logger):
+        """Benchmark target should run pytest in benchmark-only mode against the benchmarks folder."""
+        proc = run_make(logger, ["benchmark"])
+        out = proc.stdout
+        assert "no rule to make target" not in proc.stderr.lower()
+        assert "/benchmarks/" in out
+        assert "--benchmark-only" in out
+
+    def test_stress_target_dry_run(self, logger):
+        """Stress target should run pytest selecting the stress marker."""
+        proc = run_make(logger, ["stress"])
+        out = proc.stdout
+        assert "no rule to make target" not in proc.stderr.lower()
+        assert "uv run pytest" in out
+        assert "-m stress" in out
+
+    def test_hypothesis_test_target_dry_run(self, logger):
+        """Hypothesis-test target should run pytest selecting property-based tests with statistics."""
+        proc = run_make(logger, ["hypothesis-test"])
+        out = proc.stdout
+        assert "no rule to make target" not in proc.stderr.lower()
+        assert '-m "hypothesis or property"' in out
+        assert "--hypothesis-show-statistics" in out
+
+    def test_mutation_target_dry_run(self, logger):
+        """Mutation target should run mutmut against SOURCE_FOLDER with the tests directory."""
+        proc = run_make(logger, ["mutation"])
+        out = proc.stdout
+        assert "no rule to make target" not in proc.stderr.lower()
+        assert "mutmut run" in out
+        assert "--paths-to-mutate=" in out
+
+    def test_test_pyproject_target_dry_run(self, logger):
+        """Test-pyproject target should run the pyproject structure test module via pytest."""
+        proc = run_make(logger, ["test-pyproject"])
+        out = proc.stdout
+        assert "no rule to make target" not in proc.stderr.lower()
+        assert "uv run pytest .rhiza/tests/structure/test_pyproject.py" in out
+
+    def test_all_target_chains_ci_subtargets(self, logger):
+        """The `all` aggregator should chain the CI sub-targets (fmt, test, docs-coverage, security)."""
+        proc = run_make(logger, ["all"])
+        out = proc.stdout
+        assert "no rule to make target" not in proc.stderr.lower()
+        # Markers proving the prerequisite chain expands each sub-target's recipe.
+        assert "pre-commit run --all-files" in out  # fmt
+        assert "uv run pytest" in out  # test / rhiza-test
+        assert "uv run interrogate" in out  # docs-coverage
+        assert "pip_audit_policy.py" in out  # security
+
     def test_python_version_defaults_to_3_13_if_missing(self, logger, tmp_path):
         """`PYTHON_VERSION` should default to `3.13` if .python-version is missing."""
         # Ensure .python-version does not exist
@@ -209,8 +259,7 @@ class TestMakefile:
         """Suppression-audit target should invoke the Python audit script via uv run in dry-run output."""
         proc = run_make(logger, ["suppression-audit"])
         out = proc.stdout
-        assert "uv run python" in out
-        assert "suppression_audit.py" in out
+        assert "run .rhiza/utils/suppression_audit.py" in out
 
     def test_license_target_dry_run(self, logger):
         """License target should invoke pip-licenses via uv run --with in dry-run output."""
@@ -225,6 +274,22 @@ class TestMakefile:
         proc = run_make(logger, ["license", "LICENSE_FAIL_ON=MIT;Apache"])
         out = proc.stdout
         assert '--fail-on="MIT;Apache"' in out
+
+    def test_semgrep_target_dry_run(self, logger):
+        """Semgrep target should invoke semgrep against SOURCE_FOLDER with the rhiza config."""
+        proc = run_make(logger, ["semgrep"])
+        out = proc.stdout
+        assert "no rule to make target" not in proc.stderr.lower()
+        assert "Running Semgrep" in out
+        assert "semgrep --config .rhiza/semgrep.yml" in out
+
+    def test_todos_target_dry_run(self, logger):
+        """Todos target should grep the codebase for TODO/FIXME/HACK markers."""
+        proc = run_make(logger, ["todos"])
+        out = proc.stdout
+        assert "no rule to make target" not in proc.stderr.lower()
+        assert "(TODO|FIXME|HACK):" in out
+        assert "grep -nHE" in out
 
     def test_serve_target_uses_uv_run_python_http_server(self, logger):
         """Serve target should use uv run instead of directly calling python3."""

--- a/.rhiza/tests/utils/test_pip_audit_policy.py
+++ b/.rhiza/tests/utils/test_pip_audit_policy.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import runpy
 import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 from test_utils import strip_ansi
 
 
@@ -126,3 +128,20 @@ def test_main_fails_for_runtime_vulnerabilities_and_warns_for_tooling(root, monk
     output = strip_ansi(capsys.readouterr().out)
     assert "[WARN] setuptools==70.0: PYSEC-2024-2 (tooling — not failing build)" in output
     assert "[FAIL] requests==2.0.0: GHSA-abcd, CVE-2024-5678" in output
+
+
+def test_module_entrypoint_exits_with_main_return_code(root, monkeypatch, capsys):
+    """Running the module as __main__ forwards main()'s return code to sys.exit."""
+    module_path = root / ".rhiza" / "utils" / "pip_audit_policy.py"
+
+    monkeypatch.setattr(sys, "argv", ["pip_audit_policy.py"])
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(str(module_path), run_name="__main__")
+
+    assert excinfo.value.code == 0
+    assert "[OK] pip-audit: no vulnerabilities found" in strip_ansi(capsys.readouterr().out)

--- a/.rhiza/tests/utils/test_suppression_audit.py
+++ b/.rhiza/tests/utils/test_suppression_audit.py
@@ -1,41 +1,72 @@
-"""Unit tests for suppression_audit.py helpers."""
+"""Unit tests for the suppression-audit utility modules."""
 
 from __future__ import annotations
 
 import importlib.util
+import runpy
 import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+from test_utils import strip_ansi
 
-def _load_module(root: Path):
-    """Import the repo's suppression_audit.py utility as a standalone module."""
-    module_path = root / ".rhiza" / "utils" / "suppression_audit.py"
-    spec = importlib.util.spec_from_file_location("suppression_audit", module_path)
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    sys.modules["suppression_audit"] = module
-    spec.loader.exec_module(module)
-    return module
+
+def _load_modules(root: Path):
+    """Import the three suppression_* utility modules as standalone modules.
+
+    Each module is loaded from its file under ``.rhiza/utils`` and registered in
+    ``sys.modules`` under its own name so their cross-imports resolve to these
+    instances. Tests reference each symbol on the module that owns it:
+    ``parse`` (scanning/parsing), ``report`` (rendering + pip-audit), and
+    ``audit`` (the thin CLI orchestrator).
+
+    Args:
+        root: Repository root containing the ``.rhiza/utils`` directory.
+
+    Returns:
+        A namespace with ``parse``, ``report``, and ``audit`` module objects.
+    """
+    utils_dir = root / ".rhiza" / "utils"
+
+    loaded = {}
+    for name in ("suppression_parse", "suppression_report", "suppression_audit"):
+        spec = importlib.util.spec_from_file_location(name, utils_dir / f"{name}.py")
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        loaded[name] = module
+
+    return SimpleNamespace(
+        parse=loaded["suppression_parse"],
+        report=loaded["suppression_report"],
+        audit=loaded["suppression_audit"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# CVE extraction and pip-audit parsing
+# ---------------------------------------------------------------------------
 
 
 def test_nosec_cves_extracts_only_nosec_entries(root):
     """Only # nosec suppressions with CVE tags should be captured."""
-    module = _load_module(root)
+    parse = _load_modules(root).parse
 
     suppressions = [
-        module.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234"),
-        module.Suppression(file="b.py", line_no=2, kind="noqa", raw="# noqa: E501 CVE-2024-0001"),
-        module.Suppression(file="c.py", line_no=3, kind="nosec", raw="# nosec B602"),
+        parse.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234"),
+        parse.Suppression(file="b.py", line_no=2, kind="noqa", raw="# noqa: E501 CVE-2024-0001"),
+        parse.Suppression(file="c.py", line_no=3, kind="nosec", raw="# nosec B602"),
     ]
 
-    assert module._nosec_cves(suppressions) == {"CVE-2024-1234"}
+    assert parse.nosec_cves(suppressions) == {"CVE-2024-1234"}
 
 
 def test_active_pip_audit_ids_collects_ids_and_aliases(root, monkeypatch):
     """pip-audit JSON IDs and aliases should be normalized and returned."""
-    module = _load_module(root)
+    report = _load_modules(root).report
 
     payload = """
     {
@@ -46,9 +77,322 @@ def test_active_pip_audit_ids_collects_ids_and_aliases(root, monkeypatch):
     """
 
     monkeypatch.setattr(
-        module.subprocess,
+        report.subprocess,
         "run",
         lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout=payload, stderr=""),
     )
 
-    assert module._active_pip_audit_ids([]) == {"PYSEC-1", "CVE-2024-1111"}
+    assert report._active_pip_audit_ids([]) == {"PYSEC-1", "CVE-2024-1111"}
+
+
+def test_active_pip_audit_ids_raises_on_unexpected_returncode(root, monkeypatch, capsys):
+    """A return code outside {0, 1} should surface a RuntimeError and echo output."""
+    report = _load_modules(root).report
+
+    monkeypatch.setattr(
+        report.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=2, stdout="boom-out", stderr="boom-err"),
+    )
+
+    with pytest.raises(RuntimeError, match="pip-audit execution failed"):
+        report._active_pip_audit_ids([])
+
+    captured = capsys.readouterr()
+    assert "boom-out" in captured.out
+    assert "boom-err" in captured.err
+
+
+def test_active_pip_audit_ids_raises_on_invalid_json(root, monkeypatch):
+    """Non-JSON pip-audit output should raise a descriptive RuntimeError."""
+    report = _load_modules(root).report
+
+    monkeypatch.setattr(
+        report.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="not-json", stderr=""),
+    )
+
+    with pytest.raises(RuntimeError, match="did not return valid JSON"):
+        report._active_pip_audit_ids([])
+
+
+# ---------------------------------------------------------------------------
+# Scanning helpers
+# ---------------------------------------------------------------------------
+
+
+def test_should_skip_matches_skip_dirs(root):
+    """Paths inside a skip-listed directory should be skipped."""
+    parse = _load_modules(root).parse
+
+    assert parse._should_skip(Path(".venv") / "lib" / "mod.py") is True
+    assert parse._should_skip(Path("tests") / "test_mod.py") is True
+    assert parse._should_skip(Path("src") / "pkg" / "mod.py") is False
+
+
+def test_is_rhiza_repo_detects_template_marker(root, tmp_path):
+    """A project with .rhiza/template.yml is a consumer repo, otherwise the framework repo."""
+    parse = _load_modules(root).parse
+
+    assert parse._is_rhiza_repo(tmp_path) is True
+
+    (tmp_path / ".rhiza").mkdir()
+    (tmp_path / ".rhiza" / "template.yml").write_text("upstream: x\n", encoding="utf-8")
+    assert parse._is_rhiza_repo(tmp_path) is False
+
+
+def test_scan_file_detects_every_suppression_kind(root, tmp_path):
+    """scan_file should classify each suppression family and capture its codes."""
+    parse = _load_modules(root).parse
+
+    target = tmp_path / "sample.py"
+    target.write_text(
+        "\n".join(
+            [
+                "x = 1  # noqa: E501, F401",
+                "y = 2  # nosec B101",
+                "z: int = 3  # type: ignore[assignment]",
+                "w = 4  # pragma: no cover",
+                "v = 5  # noinspection PyUnresolvedReferences",
+                "ok = 6  # just a normal comment",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    found = {sup.kind: sup for sup in parse.scan_file(target)}
+
+    assert found["noqa"].codes == ["E501", "F401"]
+    assert found["nosec"].codes == ["B101"]
+    assert found["type:ignore"].codes == ["assignment"]
+    assert found["no cover"].codes == []
+    assert found["noinspection"].codes == ["PyUnresolvedReferences"]
+    assert "just a normal comment" not in {s.raw for s in parse.scan_file(target)}
+
+
+def test_scan_file_returns_empty_for_unreadable_file(root, tmp_path):
+    """A missing file should yield no suppressions rather than raising."""
+    parse = _load_modules(root).parse
+
+    assert parse.scan_file(tmp_path / "does-not-exist.py") == []
+
+
+def test_scan_file_swallows_tokenize_errors(root, tmp_path):
+    """A file that fails to tokenize should be skipped without raising."""
+    parse = _load_modules(root).parse
+
+    broken = tmp_path / "broken.py"
+    broken.write_text('x = "unterminated  # noqa: E501\n', encoding="utf-8")
+
+    # Should not raise; tokenize errors are caught and the partial result returned.
+    assert isinstance(parse.scan_file(broken), list)
+
+
+def test_count_non_empty_lines(root, tmp_path):
+    """Only lines with non-whitespace content should be counted."""
+    parse = _load_modules(root).parse
+
+    target = tmp_path / "lines.py"
+    target.write_text("a = 1\n\n   \nb = 2\n", encoding="utf-8")
+
+    assert parse.count_non_empty_lines(target) == 2
+    assert parse.count_non_empty_lines(tmp_path / "missing.py") == 0
+
+
+# ---------------------------------------------------------------------------
+# Grading and rendering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("density", "expected"),
+    [(0.0, "A+"), (0.5, "A"), (1.0, "B"), (2.0, "C"), (3.0, "D"), (10.0, "F")],
+)
+def test_compute_grade_thresholds(root, density, expected):
+    """Grades should map to the documented density thresholds."""
+    parse = _load_modules(root).parse
+
+    assert parse.compute_grade(density) == expected
+
+
+def test_bar_renders_fixed_width(root):
+    """The histogram bar is always _BAR_WIDTH wide, all-empty when max is zero."""
+    report = _load_modules(root).report
+
+    assert report._bar(0, 0) == "░" * report._BAR_WIDTH
+    bar = report._bar(5, 10)
+    assert len(bar) == report._BAR_WIDTH
+    assert "█" in bar
+    assert "░" in bar
+
+
+# ---------------------------------------------------------------------------
+# Collection
+# ---------------------------------------------------------------------------
+
+
+def test_collect_suppressions_includes_rhiza_dir_in_framework_repo(root, tmp_path):
+    """In the framework repo (no template.yml) .rhiza/ files are scanned."""
+    parse = _load_modules(root).parse
+
+    (tmp_path / ".rhiza" / "utils").mkdir(parents=True)
+    (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
+    (tmp_path / ".rhiza" / "utils" / "helper.py").write_text("b = 2  # nosec B101\n", encoding="utf-8")
+
+    py_files, suppressions, total_lines = parse.collect_suppressions(tmp_path)
+
+    scanned = {Path(s.file).name for s in suppressions}
+    assert scanned == {"app.py", "helper.py"}
+    assert total_lines == 2
+    assert len(py_files) == 2
+
+
+def test_collect_suppressions_skips_files_in_skip_dirs(root, tmp_path):
+    """Python files inside skip-listed directories (e.g. tests/) are excluded from the scan."""
+    parse = _load_modules(root).parse
+
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
+    (tmp_path / "tests" / "test_app.py").write_text("b = 2  # nosec B101\n", encoding="utf-8")
+
+    py_files, suppressions, _total = parse.collect_suppressions(tmp_path)
+
+    scanned = {Path(s.file).name for s in suppressions}
+    assert scanned == {"app.py"}
+    assert {p.name for p in py_files} == {"app.py"}
+
+
+def test_collect_suppressions_skips_rhiza_dir_in_consumer_repo(root, tmp_path):
+    """In a consumer repo (template.yml present) the .rhiza/ tree is excluded."""
+    parse = _load_modules(root).parse
+
+    (tmp_path / ".rhiza").mkdir()
+    (tmp_path / ".rhiza" / "template.yml").write_text("upstream: x\n", encoding="utf-8")
+    (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
+    (tmp_path / ".rhiza" / "framework.py").write_text("b = 2  # nosec B101\n", encoding="utf-8")
+
+    _py_files, suppressions, _total = parse.collect_suppressions(tmp_path)
+
+    scanned = {Path(s.file).name for s in suppressions}
+    assert scanned == {"app.py"}
+
+
+def test_print_report_with_suppressions(root, capsys):
+    """The report should render details, a histogram, and a grade when suppressions exist."""
+    mods = _load_modules(root)
+
+    suppressions = [
+        mods.parse.Suppression(file="app.py", line_no=10, kind="noqa", codes=["E501"], raw="# noqa: E501"),
+        mods.parse.Suppression(file="app.py", line_no=20, kind="nosec", codes=[], raw="# nosec"),
+    ]
+    mods.report.print_report([Path("app.py")], suppressions, total_lines=100)
+
+    out = strip_ansi(capsys.readouterr().out)
+    assert "Suppression Audit Report" in out
+    assert "app.py:10: # noqa[E501]" in out
+    assert "Histogram (by suppression code):" in out
+    assert "noqa[E501]" in out
+    assert "Grade" in out
+    assert "Suppressions    : 2" in out
+
+
+def test_print_report_without_suppressions(root, capsys):
+    """A clean codebase should report no suppressions and an empty histogram."""
+    report = _load_modules(root).report
+
+    report.print_report([Path("app.py")], [], total_lines=0)
+
+    out = strip_ansi(capsys.readouterr().out)
+    assert "No inline suppressions found." in out
+    assert "(none)" in out
+
+
+# ---------------------------------------------------------------------------
+# Stale-CVE gate and entry point
+# ---------------------------------------------------------------------------
+
+
+def test_check_stale_nosec_cves_no_suppressions(root, capsys):
+    """With no CVE-tagged # nosec comments the check passes without calling pip-audit."""
+    report = _load_modules(root).report
+
+    assert report.check_stale_nosec_cves([], []) == 0
+    assert "No CVE-tagged # nosec suppressions found." in strip_ansi(capsys.readouterr().out)
+
+
+def test_check_stale_nosec_cves_flags_stale(root, monkeypatch, capsys):
+    """A suppressed CVE that pip-audit no longer reports is flagged as stale."""
+    mods = _load_modules(root)
+
+    suppressions = [mods.parse.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234")]
+    monkeypatch.setattr(mods.report, "_active_pip_audit_ids", lambda _args: set())
+
+    assert mods.report.check_stale_nosec_cves(suppressions, []) == 1
+    assert "Stale # nosec CVE suppressions detected:" in strip_ansi(capsys.readouterr().out)
+
+
+def test_check_stale_nosec_cves_all_active(root, monkeypatch, capsys):
+    """A suppressed CVE that pip-audit still reports is considered current."""
+    mods = _load_modules(root)
+
+    suppressions = [mods.parse.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234")]
+    monkeypatch.setattr(mods.report, "_active_pip_audit_ids", lambda _args: {"CVE-2024-1234"})
+
+    assert mods.report.check_stale_nosec_cves(suppressions, []) == 0
+    assert "match active pip-audit findings." in strip_ansi(capsys.readouterr().out)
+
+
+def test_check_stale_nosec_cves_pip_audit_failure(root, monkeypatch, capsys):
+    """A pip-audit RuntimeError should surface as exit code 2."""
+    mods = _load_modules(root)
+
+    suppressions = [mods.parse.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234")]
+    # A return code outside {0, 1} makes the real _active_pip_audit_ids raise,
+    # which check_stale_nosec_cves should translate into exit code 2.
+    monkeypatch.setattr(
+        mods.report.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=2, stdout="", stderr=""),
+    )
+
+    assert mods.report.check_stale_nosec_cves(suppressions, []) == 2
+    assert "pip-audit execution failed" in strip_ansi(capsys.readouterr().out)
+
+
+def test_main_reports_and_returns_zero(root, monkeypatch, tmp_path, capsys):
+    """A plain run scans the working tree, prints the report, and returns 0."""
+    audit = _load_modules(root).audit
+
+    (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    assert audit.main([]) == 0
+    assert "Suppression Audit Report" in strip_ansi(capsys.readouterr().out)
+
+
+def test_main_with_stale_gate_returns_one(root, monkeypatch, tmp_path, capsys):
+    """The --fail-stale-nosec-cve flag fails when a suppressed CVE is no longer active."""
+    mods = _load_modules(root)
+
+    (tmp_path / "app.py").write_text("a = 1  # nosec B101 CVE-2024-9999\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mods.report, "_active_pip_audit_ids", lambda _args: set())
+
+    assert mods.audit.main(["--fail-stale-nosec-cve"]) == 1
+    assert "Stale # nosec CVE suppressions detected:" in strip_ansi(capsys.readouterr().out)
+
+
+def test_module_entrypoint_exits_with_main_return_code(root, monkeypatch, tmp_path, capsys):
+    """Running the module as __main__ forwards main()'s return code to sys.exit."""
+    module_path = root / ".rhiza" / "utils" / "suppression_audit.py"
+
+    (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["suppression_audit.py"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(str(module_path), run_name="__main__")
+
+    assert excinfo.value.code == 0
+    assert "Suppression Audit Report" in strip_ansi(capsys.readouterr().out)

--- a/.rhiza/utils/pip_audit_policy.py
+++ b/.rhiza/utils/pip_audit_policy.py
@@ -1,3 +1,7 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
 """Run pip-audit with a tiered vulnerability policy.
 
 Fails the build for vulnerabilities in runtime dependencies.

--- a/.rhiza/utils/suppression_audit.py
+++ b/.rhiza/utils/suppression_audit.py
@@ -1,3 +1,7 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
 """Suppression audit: scan codebase for inline suppressions of security, coverage, docs, and linting.
 
 Detects and reports on inline suppression comments such as:
@@ -8,375 +12,29 @@ Detects and reports on inline suppression comments such as:
 - ``# noinspection CODE`` (PyCharm/IDE suppressions)
 
 Outputs a detailed per-file report, an ASCII histogram, and a letter grade.
+
+This module is the thin orchestrator and CLI. Parsing lives in
+:mod:`suppression_parse` and reporting/output lives in :mod:`suppression_report`.
 """
 
 from __future__ import annotations
 
 import argparse
-import io
-import json
-import re
-import shutil
-import subprocess  # nosec B404
 import sys
-import tokenize
-from collections import Counter
-from dataclasses import dataclass, field
 from pathlib import Path
 
-# ---------------------------------------------------------------------------
-# Suppression patterns
-# ---------------------------------------------------------------------------
-
-# Each entry: (kind_label, compiled_regex).
-# The first capture group (if any) captures the comma-separated rule codes.
-SUPPRESSION_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
-    (
-        "noqa",
-        re.compile(r"#\s*noqa(?:\s*:\s*([A-Z0-9]+(?:\s*,\s*[A-Z0-9]+)*))?", re.IGNORECASE),
-    ),
-    (
-        "nosec",
-        re.compile(r"#\s*nosec(?:\s*:?\s*([A-Z0-9]+(?:\s*,\s*[A-Z0-9]+)*))?", re.IGNORECASE),
-    ),
-    (
-        "type:ignore",
-        re.compile(r"#\s*type\s*:\s*ignore(?:\[([^\]]+)\])?", re.IGNORECASE),
-    ),
-    (
-        "no cover",
-        re.compile(r"#\s*pragma\s*:\s*no\s+cover", re.IGNORECASE),
-    ),
-    (
-        "noinspection",
-        re.compile(r"#\s*noinspection\s+(\w+)", re.IGNORECASE),
-    ),
-]
-
-# Directories to skip during the scan
-_SKIP_DIRS = {".venv", ".git", "node_modules", ".tox", "build", "dist", "__pycache__", "tests"}
-
-
-# ---------------------------------------------------------------------------
-# Data model
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class Suppression:
-    """A single suppression comment found in the codebase.
-
-    Attributes:
-        file: Path to the file containing the suppression.
-        line_no: 1-based line number of the comment.
-        kind: Suppression family label (e.g. ``"noqa"``, ``"nosec"``,
-            ``"type:ignore"``, ``"no cover"``, ``"noinspection"``).
-        codes: The specific rule codes named in the comment, if any
-            (e.g. ``["E501", "F401"]``); empty for blanket suppressions.
-        raw: The verbatim comment text, used for downstream CVE extraction.
-    """
-
-    file: str
-    line_no: int
-    kind: str
-    codes: list[str] = field(default_factory=list)
-    raw: str = ""
-
-
-# ---------------------------------------------------------------------------
-# Scanning helpers
-# ---------------------------------------------------------------------------
-
-
-def _should_skip(path: Path) -> bool:
-    """Return True if any path component is in the skip-list."""
-    return bool(_SKIP_DIRS.intersection(path.parts))
-
-
-def _is_rhiza_repo(root: Path) -> bool:
-    """Return True if *root* is the rhiza framework repo itself.
-
-    Consumer repos have a ``.rhiza/template.yml`` file that records the upstream
-    rhiza repository reference. The rhiza repo itself never has this file — its
-    absence is the reliable signal that we are running inside the framework repo.
-    """
-    return not (root / ".rhiza" / "template.yml").exists()
-
-
-def scan_file(path: Path) -> list[Suppression]:
-    """Scan a single Python file and return all suppressions found.
-
-    Uses Python's ``tokenize`` module so that only actual comment tokens are
-    inspected — patterns that appear inside string literals or docstrings are
-    correctly ignored.
-
-    Args:
-        path: Path to the Python file to scan.
-
-    Returns:
-        A list of :class:`Suppression` records, one per matching comment line, in
-        source order. Empty if the file cannot be read or fails to tokenize.
-    """
-    suppressions: list[Suppression] = []
-    try:
-        source = path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return suppressions
-
-    try:
-        tokens = tokenize.generate_tokens(io.StringIO(source).readline)
-        for tok_type, tok_string, tok_start, _tok_end, _line in tokens:
-            if tok_type != tokenize.COMMENT:
-                continue
-            line_no = tok_start[0]
-            for kind, pattern in SUPPRESSION_PATTERNS:
-                match = pattern.search(tok_string)
-                if match:
-                    codes_raw = match.group(1) if match.lastindex and match.group(1) else ""
-                    codes = [c.strip() for c in codes_raw.split(",") if c.strip()] if codes_raw else []
-                    suppressions.append(
-                        Suppression(
-                            file=str(path),
-                            line_no=line_no,
-                            kind=kind,
-                            codes=codes,
-                            raw=tok_string.strip(),
-                        )
-                    )
-                    break  # count each comment line once
-    except (tokenize.TokenError, IndentationError):
-        pass  # skip files with tokenization errors or bad indentation
-
-    return suppressions
-
-
-def count_non_empty_lines(path: Path) -> int:
-    """Count non-empty lines in a file.
-
-    Args:
-        path: Path to the file to measure.
-
-    Returns:
-        The number of lines that contain non-whitespace characters, or ``0`` if
-        the file cannot be read. Used as the denominator for suppression density.
-    """
-    try:
-        return sum(1 for line in path.read_text(encoding="utf-8", errors="replace").splitlines() if line.strip())
-    except OSError:
-        return 0
-
-
-# ---------------------------------------------------------------------------
-# Grading
-# ---------------------------------------------------------------------------
-
-# Grade thresholds: suppressions per 100 lines of code
-_GRADE_THRESHOLDS: list[tuple[float, str]] = [
-    (0.0, "A+"),
-    (0.5, "A"),
-    (1.0, "B"),
-    (2.0, "C"),
-    (3.0, "D"),
-]
-
-
-def compute_grade(density: float) -> str:
-    """Return a letter grade based on suppression density.
-
-    Args:
-        density: Number of suppressions per 100 non-empty lines of code.
-
-    Returns:
-        A letter grade from ``"A+"`` (zero suppressions) down to ``"F"``,
-        derived from :data:`_GRADE_THRESHOLDS`.
-    """
-    grade = "F"
-    for threshold, letter in _GRADE_THRESHOLDS:
-        if density <= threshold:
-            grade = letter
-            break
-    return grade
-
-
-# ---------------------------------------------------------------------------
-# Rendering helpers
-# ---------------------------------------------------------------------------
-
-_BAR_WIDTH = 24
-
-
-def _bar(count: int, max_count: int) -> str:
-    """Render a fixed-width ASCII progress bar."""
-    if max_count == 0:
-        return "░" * _BAR_WIDTH
-    filled = round(count / max_count * _BAR_WIDTH)
-    return "█" * filled + "░" * (_BAR_WIDTH - filled)
-
-
-_GRADE_COLOURS = {
-    "A+": "\033[92m",  # bright green
-    "A": "\033[32m",  # green
-    "B": "\033[32m",  # green
-    "C": "\033[33m",  # yellow
-    "D": "\033[33m",  # yellow
-    "F": "\033[31m",  # red
-}
-_RESET = "\033[0m"
-_BOLD = "\033[1m"
-_BLUE = "\033[36m"
-_YELLOW = "\033[33m"
-_GREEN = "\033[32m"
-_RED = "\033[31m"
-_CVE_RE = re.compile(r"\bCVE-\d{4}-\d+\b", re.IGNORECASE)
-
-
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
-
-
-def _active_pip_audit_ids(extra_args: list[str]) -> set[str]:
-    """Return vulnerability IDs currently reported by pip-audit."""
-    uvx = shutil.which("uvx") or "uvx"
-    cmd = [uvx, "pip-audit", "--format", "json", *extra_args]
-    proc = subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603  # nosec B603
-
-    if proc.returncode not in {0, 1}:
-        sys.stdout.write(proc.stdout)
-        sys.stderr.write(proc.stderr)
-        raise RuntimeError("pip-audit execution failed")
-
-    try:
-        data = json.loads(proc.stdout or "{}")
-    except json.JSONDecodeError as exc:
-        raise RuntimeError("pip-audit did not return valid JSON") from exc
-
-    ids: set[str] = set()
-    for dep in data.get("dependencies", []):
-        for vuln in dep.get("vulns", []):
-            vuln_id = vuln.get("id")
-            if vuln_id:
-                ids.add(str(vuln_id).upper())
-            for alias in vuln.get("aliases", []):
-                ids.add(str(alias).upper())
-    return ids
-
-
-def _nosec_cves(suppressions: list[Suppression]) -> set[str]:
-    """Extract CVE identifiers referenced by # nosec suppressions."""
-    cves: set[str] = set()
-    for sup in suppressions:
-        if sup.kind != "nosec":
-            continue
-        cves.update(match.upper() for match in _CVE_RE.findall(sup.raw))
-    return cves
-
-
-def _collect_suppressions(root: Path) -> tuple[list[Path], list[Suppression], int]:
-    """Collect Python files, suppressions, and non-empty line counts."""
-    in_rhiza_repo = _is_rhiza_repo(root)
-
-    def _include(p: Path) -> bool:
-        """Return True when a Python file should be scanned for suppressions."""
-        if _should_skip(p):
-            return False
-        # In consumer repos, skip the .rhiza/ framework directory entirely
-        return not (not in_rhiza_repo and ".rhiza" in p.parts)
-
-    py_files = sorted(p for p in root.rglob("*.py") if _include(p))
-
-    all_suppressions: list[Suppression] = []
-    total_lines = 0
-    for py_file in py_files:
-        all_suppressions.extend(scan_file(py_file))
-        total_lines += count_non_empty_lines(py_file)
-
-    return py_files, all_suppressions, total_lines
-
-
-def _print_report(py_files: list[Path], all_suppressions: list[Suppression], total_lines: int) -> None:
-    """Print the suppression audit report."""
-    # -----------------------------------------------------------------------
-    # Header
-    # -----------------------------------------------------------------------
-    print()
-    print(f"{_BOLD}{'=' * 62}{_RESET}")
-    print(f"{_BOLD}  Suppression Audit Report{_RESET}")
-    print(f"{_BOLD}{'=' * 62}{_RESET}")
-    print()
-
-    # -----------------------------------------------------------------------
-    # Detailed per-file report
-    # -----------------------------------------------------------------------
-    print(f"{_BOLD}Detailed Report:{_RESET}")
-    if all_suppressions:
-        for sup in all_suppressions:
-            codes_str = f"[{', '.join(sup.codes)}]" if sup.codes else ""
-            print(f"  {_YELLOW}{sup.file}{_RESET}:{_GREEN}{sup.line_no}{_RESET}: # {sup.kind}{codes_str}")
-    else:
-        print(f"  {_GREEN}No inline suppressions found.{_RESET}")
-    print()
-
-    # -----------------------------------------------------------------------
-    # Histogram by code
-    # -----------------------------------------------------------------------
-    print(f"{_BOLD}Histogram (by suppression code):{_RESET}")
-    code_counter: Counter[str] = Counter()
-    for sup in all_suppressions:
-        if sup.codes:
-            for code in sup.codes:
-                code_counter[f"{sup.kind}[{code}]"] += 1
-        else:
-            code_counter[f"{sup.kind}"] += 1
-    if code_counter:
-        max_code_count = max(code_counter.values())
-        total_code_count = sum(code_counter.values())
-        for label, count in code_counter.most_common():
-            pct = count / total_code_count * 100
-            print(f"  {label:<20} {_BLUE}{_bar(count, max_code_count)}{_RESET}  {count:>3}  ({pct:.0f}%)")
-    else:
-        print("  (none)")
-    print()
-
-    # -----------------------------------------------------------------------
-    # Summary + Grade
-    # -----------------------------------------------------------------------
-    density = (len(all_suppressions) / total_lines * 100) if total_lines > 0 else 0.0
-    grade = compute_grade(density)
-    grade_colour = _GRADE_COLOURS.get(grade, _RESET)
-
-    print(f"{_BOLD}Summary:{_RESET}")
-    print(f"  Files scanned   : {len(py_files)}")
-    print(f"  Lines scanned   : {total_lines:,}")
-    print(f"  Suppressions    : {len(all_suppressions)}")
-    print(f"  Density         : {density:.2f} per 100 lines")
-    print()
-    print(f"  Grade           : {grade_colour}{_BOLD}{grade}{_RESET}")
-    print()
-
-
-def _check_stale_nosec_cves(suppressions: list[Suppression], pip_audit_args: list[str]) -> int:
-    """Validate CVE-tagged # nosec suppressions against active pip-audit findings."""
-    suppressed_cves = _nosec_cves(suppressions)
-    if not suppressed_cves:
-        print(f"{_GREEN}[OK]{_RESET} No CVE-tagged # nosec suppressions found.")
-        return 0
-
-    try:
-        active_cves = _active_pip_audit_ids(pip_audit_args)
-    except RuntimeError as exc:
-        print(f"{_RED}[FAIL]{_RESET} {exc}")
-        return 2
-
-    stale = sorted(cve for cve in suppressed_cves if cve not in active_cves)
-    if stale:
-        print(f"{_RED}[FAIL]{_RESET} Stale # nosec CVE suppressions detected:")
-        for cve in stale:
-            print(f"  - {cve}")
-        return 1
-
-    print(f"{_GREEN}[OK]{_RESET} All CVE-tagged # nosec suppressions match active pip-audit findings.")
-    return 0
+# Allow the parsing/reporting submodules to be imported whether this file is run
+# directly (``python .rhiza/utils/suppression_audit.py``) or loaded by path via
+# ``importlib`` (tests and fuzz harness), by ensuring its own directory is on the
+# import path.
+_UTILS_DIR = str(Path(__file__).resolve().parent)
+if _UTILS_DIR not in sys.path:
+    sys.path.insert(0, _UTILS_DIR)
+
+from suppression_parse import collect_suppressions  # noqa: E402
+from suppression_report import check_stale_nosec_cves, print_report  # noqa: E402
+
+__all__ = ["main"]
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -414,11 +72,11 @@ def main(argv: list[str] | None = None) -> int:
     args, pip_audit_args = parser.parse_known_args(argv)
 
     root = Path(".")
-    py_files, all_suppressions, total_lines = _collect_suppressions(root)
-    _print_report(py_files, all_suppressions, total_lines)
+    py_files, all_suppressions, total_lines = collect_suppressions(root)
+    print_report(py_files, all_suppressions, total_lines)
 
     if args.fail_stale_nosec_cve:
-        return _check_stale_nosec_cves(all_suppressions, pip_audit_args)
+        return check_stale_nosec_cves(all_suppressions, pip_audit_args)
 
     return 0
 

--- a/.rhiza/utils/suppression_parse.py
+++ b/.rhiza/utils/suppression_parse.py
@@ -1,0 +1,251 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+"""Parsing layer for the suppression audit: scan source for inline suppressions.
+
+This module owns the *parsing* concerns of the suppression audit:
+
+- The suppression comment patterns (``# noqa``, ``# nosec``, ``# type: ignore``,
+  ``# pragma: no cover``, ``# noinspection``).
+- The :class:`Suppression` data model.
+- File scanning via Python's ``tokenize`` module so that only real comment
+  tokens are inspected.
+- Density grading and CVE extraction from ``# nosec`` comments.
+
+Rendering and process-exit logic live in :mod:`suppression_report`; orchestration
+and the CLI live in :mod:`suppression_audit`.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import tokenize
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Suppression patterns
+# ---------------------------------------------------------------------------
+
+# Each entry: (kind_label, compiled_regex).
+# The first capture group (if any) captures the comma-separated rule codes.
+SUPPRESSION_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    (
+        "noqa",
+        re.compile(r"#\s*noqa(?:\s*:\s*([A-Z0-9]+(?:\s*,\s*[A-Z0-9]+)*))?", re.IGNORECASE),
+    ),
+    (
+        "nosec",
+        re.compile(r"#\s*nosec(?:\s*:?\s*([A-Z0-9]+(?:\s*,\s*[A-Z0-9]+)*))?", re.IGNORECASE),
+    ),
+    (
+        "type:ignore",
+        re.compile(r"#\s*type\s*:\s*ignore(?:\[([^\]]+)\])?", re.IGNORECASE),
+    ),
+    (
+        "no cover",
+        re.compile(r"#\s*pragma\s*:\s*no\s+cover", re.IGNORECASE),
+    ),
+    (
+        "noinspection",
+        re.compile(r"#\s*noinspection\s+(\w+)", re.IGNORECASE),
+    ),
+]
+
+# Directories to skip during the scan
+_SKIP_DIRS = {".venv", ".git", "node_modules", ".tox", "build", "dist", "__pycache__", "tests"}
+
+_CVE_RE = re.compile(r"\bCVE-\d{4}-\d+\b", re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Suppression:
+    """A single suppression comment found in the codebase.
+
+    Attributes:
+        file: Path to the file containing the suppression.
+        line_no: 1-based line number of the comment.
+        kind: Suppression family label (e.g. ``"noqa"``, ``"nosec"``,
+            ``"type:ignore"``, ``"no cover"``, ``"noinspection"``).
+        codes: The specific rule codes named in the comment, if any
+            (e.g. ``["E501", "F401"]``); empty for blanket suppressions.
+        raw: The verbatim comment text, used for downstream CVE extraction.
+    """
+
+    file: str
+    line_no: int
+    kind: str
+    codes: list[str] = field(default_factory=list)
+    raw: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Scanning helpers
+# ---------------------------------------------------------------------------
+
+
+def _should_skip(path: Path) -> bool:
+    """Return True if any path component is in the skip-list."""
+    return bool(_SKIP_DIRS.intersection(path.parts))
+
+
+def _is_rhiza_repo(root: Path) -> bool:
+    """Return True if *root* is the rhiza framework repo itself.
+
+    Consumer repos have a ``.rhiza/template.yml`` file that records the upstream
+    rhiza repository reference. The rhiza repo itself never has this file — its
+    absence is the reliable signal that we are running inside the framework repo.
+    """
+    return not (root / ".rhiza" / "template.yml").exists()
+
+
+def scan_file(path: Path) -> list[Suppression]:
+    """Scan a single Python file and return all suppressions found.
+
+    Uses Python's ``tokenize`` module so that only actual comment tokens are
+    inspected — patterns that appear inside string literals or docstrings are
+    correctly ignored.
+
+    Args:
+        path: Path to the Python file to scan.
+
+    Returns:
+        A list of :class:`Suppression` records, one per matching comment line, in
+        source order. Empty if the file cannot be read or fails to tokenize.
+    """
+    suppressions: list[Suppression] = []
+    try:
+        source = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return suppressions
+
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(source).readline)
+        for tok_type, tok_string, tok_start, _tok_end, _line in tokens:
+            if tok_type != tokenize.COMMENT:
+                continue
+            line_no = tok_start[0]
+            for kind, pattern in SUPPRESSION_PATTERNS:
+                match = pattern.search(tok_string)
+                if match:
+                    codes_raw = match.group(1) if match.lastindex and match.group(1) else ""
+                    codes = [c.strip() for c in codes_raw.split(",") if c.strip()] if codes_raw else []
+                    suppressions.append(
+                        Suppression(
+                            file=str(path),
+                            line_no=line_no,
+                            kind=kind,
+                            codes=codes,
+                            raw=tok_string.strip(),
+                        )
+                    )
+                    break  # count each comment line once
+    except (tokenize.TokenError, IndentationError):
+        pass  # skip files with tokenization errors or bad indentation
+
+    return suppressions
+
+
+def count_non_empty_lines(path: Path) -> int:
+    """Count non-empty lines in a file.
+
+    Args:
+        path: Path to the file to measure.
+
+    Returns:
+        The number of lines that contain non-whitespace characters, or ``0`` if
+        the file cannot be read. Used as the denominator for suppression density.
+    """
+    try:
+        return sum(1 for line in path.read_text(encoding="utf-8", errors="replace").splitlines() if line.strip())
+    except OSError:
+        return 0
+
+
+def collect_suppressions(root: Path) -> tuple[list[Path], list[Suppression], int]:
+    """Collect Python files, suppressions, and non-empty line counts.
+
+    Args:
+        root: Directory tree to scan recursively for Python files.
+
+    Returns:
+        A tuple ``(py_files, suppressions, total_lines)`` where ``py_files`` is
+        the sorted list of scanned files, ``suppressions`` aggregates every
+        :class:`Suppression` found, and ``total_lines`` is the combined count of
+        non-empty lines across those files.
+    """
+    in_rhiza_repo = _is_rhiza_repo(root)
+
+    def _include(p: Path) -> bool:
+        """Return True when a Python file should be scanned for suppressions."""
+        if _should_skip(p):
+            return False
+        # In consumer repos, skip the .rhiza/ framework directory entirely
+        return not (not in_rhiza_repo and ".rhiza" in p.parts)
+
+    py_files = sorted(p for p in root.rglob("*.py") if _include(p))
+
+    all_suppressions: list[Suppression] = []
+    total_lines = 0
+    for py_file in py_files:
+        all_suppressions.extend(scan_file(py_file))
+        total_lines += count_non_empty_lines(py_file)
+
+    return py_files, all_suppressions, total_lines
+
+
+def nosec_cves(suppressions: list[Suppression]) -> set[str]:
+    """Extract CVE identifiers referenced by # nosec suppressions.
+
+    Args:
+        suppressions: Suppression records to inspect.
+
+    Returns:
+        The set of upper-cased CVE identifiers found in the raw text of
+        ``# nosec`` comments. Non-``nosec`` suppressions are ignored.
+    """
+    cves: set[str] = set()
+    for sup in suppressions:
+        if sup.kind != "nosec":
+            continue
+        cves.update(match.upper() for match in _CVE_RE.findall(sup.raw))
+    return cves
+
+
+# ---------------------------------------------------------------------------
+# Grading
+# ---------------------------------------------------------------------------
+
+# Grade thresholds: suppressions per 100 lines of code
+_GRADE_THRESHOLDS: list[tuple[float, str]] = [
+    (0.0, "A+"),
+    (0.5, "A"),
+    (1.0, "B"),
+    (2.0, "C"),
+    (3.0, "D"),
+]
+
+
+def compute_grade(density: float) -> str:
+    """Return a letter grade based on suppression density.
+
+    Args:
+        density: Number of suppressions per 100 non-empty lines of code.
+
+    Returns:
+        A letter grade from ``"A+"`` (zero suppressions) down to ``"F"``,
+        derived from :data:`_GRADE_THRESHOLDS`.
+    """
+    grade = "F"
+    for threshold, letter in _GRADE_THRESHOLDS:
+        if density <= threshold:
+            grade = letter
+            break
+    return grade

--- a/.rhiza/utils/suppression_report.py
+++ b/.rhiza/utils/suppression_report.py
@@ -1,0 +1,196 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+"""Reporting layer for the suppression audit: render output and run pip-audit.
+
+This module owns the *reporting* and *output* concerns of the suppression audit:
+
+- ANSI colour constants and the ASCII histogram bar.
+- Printing the detailed per-file report, the histogram, and the density grade.
+- Cross-checking CVE-tagged ``# nosec`` comments against live pip-audit findings
+  (the ``--fail-stale-nosec-cve`` gate), including the subprocess invocation.
+
+Parsing concerns live in :mod:`suppression_parse`; orchestration and the CLI
+live in :mod:`suppression_audit`.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess  # nosec B404
+import sys
+from collections import Counter
+from pathlib import Path
+
+from suppression_parse import Suppression, compute_grade, nosec_cves
+
+# ---------------------------------------------------------------------------
+# Rendering constants
+# ---------------------------------------------------------------------------
+
+_BAR_WIDTH = 24
+
+_GRADE_COLOURS = {
+    "A+": "\033[92m",  # bright green
+    "A": "\033[32m",  # green
+    "B": "\033[32m",  # green
+    "C": "\033[33m",  # yellow
+    "D": "\033[33m",  # yellow
+    "F": "\033[31m",  # red
+}
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_BLUE = "\033[36m"
+_YELLOW = "\033[33m"
+_GREEN = "\033[32m"
+_RED = "\033[31m"
+
+
+def _bar(count: int, max_count: int) -> str:
+    """Render a fixed-width ASCII progress bar."""
+    if max_count == 0:
+        return "░" * _BAR_WIDTH
+    filled = round(count / max_count * _BAR_WIDTH)
+    return "█" * filled + "░" * (_BAR_WIDTH - filled)
+
+
+# ---------------------------------------------------------------------------
+# Report rendering
+# ---------------------------------------------------------------------------
+
+
+def print_report(py_files: list[Path], all_suppressions: list[Suppression], total_lines: int) -> None:
+    """Print the suppression audit report.
+
+    Args:
+        py_files: The Python files that were scanned.
+        all_suppressions: Every suppression discovered across those files.
+        total_lines: Combined count of non-empty lines, used as the density
+            denominator.
+    """
+    # -----------------------------------------------------------------------
+    # Header
+    # -----------------------------------------------------------------------
+    print()
+    print(f"{_BOLD}{'=' * 62}{_RESET}")
+    print(f"{_BOLD}  Suppression Audit Report{_RESET}")
+    print(f"{_BOLD}{'=' * 62}{_RESET}")
+    print()
+
+    # -----------------------------------------------------------------------
+    # Detailed per-file report
+    # -----------------------------------------------------------------------
+    print(f"{_BOLD}Detailed Report:{_RESET}")
+    if all_suppressions:
+        for sup in all_suppressions:
+            codes_str = f"[{', '.join(sup.codes)}]" if sup.codes else ""
+            print(f"  {_YELLOW}{sup.file}{_RESET}:{_GREEN}{sup.line_no}{_RESET}: # {sup.kind}{codes_str}")
+    else:
+        print(f"  {_GREEN}No inline suppressions found.{_RESET}")
+    print()
+
+    # -----------------------------------------------------------------------
+    # Histogram by code
+    # -----------------------------------------------------------------------
+    print(f"{_BOLD}Histogram (by suppression code):{_RESET}")
+    code_counter: Counter[str] = Counter()
+    for sup in all_suppressions:
+        if sup.codes:
+            for code in sup.codes:
+                code_counter[f"{sup.kind}[{code}]"] += 1
+        else:
+            code_counter[f"{sup.kind}"] += 1
+    if code_counter:
+        max_code_count = max(code_counter.values())
+        total_code_count = sum(code_counter.values())
+        for label, count in code_counter.most_common():
+            pct = count / total_code_count * 100
+            print(f"  {label:<20} {_BLUE}{_bar(count, max_code_count)}{_RESET}  {count:>3}  ({pct:.0f}%)")
+    else:
+        print("  (none)")
+    print()
+
+    # -----------------------------------------------------------------------
+    # Summary + Grade
+    # -----------------------------------------------------------------------
+    density = (len(all_suppressions) / total_lines * 100) if total_lines > 0 else 0.0
+    grade = compute_grade(density)
+    grade_colour = _GRADE_COLOURS.get(grade, _RESET)
+
+    print(f"{_BOLD}Summary:{_RESET}")
+    print(f"  Files scanned   : {len(py_files)}")
+    print(f"  Lines scanned   : {total_lines:,}")
+    print(f"  Suppressions    : {len(all_suppressions)}")
+    print(f"  Density         : {density:.2f} per 100 lines")
+    print()
+    print(f"  Grade           : {grade_colour}{_BOLD}{grade}{_RESET}")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Stale CVE gate
+# ---------------------------------------------------------------------------
+
+
+def _active_pip_audit_ids(extra_args: list[str]) -> set[str]:
+    """Return vulnerability IDs currently reported by pip-audit."""
+    uvx = shutil.which("uvx") or "uvx"
+    cmd = [uvx, "pip-audit", "--format", "json", *extra_args]
+    proc = subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603  # nosec B603
+
+    if proc.returncode not in {0, 1}:
+        sys.stdout.write(proc.stdout)
+        sys.stderr.write(proc.stderr)
+        raise RuntimeError("pip-audit execution failed")
+
+    try:
+        data = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("pip-audit did not return valid JSON") from exc
+
+    ids: set[str] = set()
+    for dep in data.get("dependencies", []):
+        for vuln in dep.get("vulns", []):
+            vuln_id = vuln.get("id")
+            if vuln_id:
+                ids.add(str(vuln_id).upper())
+            for alias in vuln.get("aliases", []):
+                ids.add(str(alias).upper())
+    return ids
+
+
+def check_stale_nosec_cves(suppressions: list[Suppression], pip_audit_args: list[str]) -> int:
+    """Validate CVE-tagged # nosec suppressions against active pip-audit findings.
+
+    Args:
+        suppressions: Suppression records to inspect for CVE-tagged ``# nosec``
+            comments.
+        pip_audit_args: Extra arguments forwarded to ``pip-audit``.
+
+    Returns:
+        A process exit code: ``0`` when no stale CVE suppressions are found,
+        ``1`` when stale suppressions are detected, or ``2`` when pip-audit
+        fails to run.
+    """
+    suppressed_cves = nosec_cves(suppressions)
+    if not suppressed_cves:
+        print(f"{_GREEN}[OK]{_RESET} No CVE-tagged # nosec suppressions found.")
+        return 0
+
+    try:
+        active_cves = _active_pip_audit_ids(pip_audit_args)
+    except RuntimeError as exc:
+        print(f"{_RED}[FAIL]{_RESET} {exc}")
+        return 2
+
+    stale = sorted(cve for cve in suppressed_cves if cve not in active_cves)
+    if stale:
+        print(f"{_RED}[FAIL]{_RESET} Stale # nosec CVE suppressions detected:")
+        for cve in stale:
+            print(f"  - {cve}")
+        return 1
+
+    print(f"{_GREEN}[OK]{_RESET} All CVE-tagged # nosec suppressions match active pip-audit findings.")
+    return 0


### PR DESCRIPTION
## Summary
Syncs the Rhiza template from **v0.19.6 → v0.19.9**.

## Conflict resolution
None required. The 3-way merge (cruft) applied all upstream changes cleanly — zero conflicts, zero `.rej` files, zero conflict markers. All 26 changed files are Rhiza-managed (`.rhiza/`, `.github/workflows/`, `.claude/`, `.pre-commit-config.yaml`). No locally-owned files (`pyproject.toml`, `ruff.toml`, `README.md`, `src/`, `tests/`) required hand-merging.

Notable upstream additions: new `.rhiza/utils/suppression_parse.py` and `.rhiza/utils/suppression_report.py` (suppression audit refactor), plus updates to pip-audit/suppression policy utilities and their tests.

## Schema
No migration needed — repo already uses the OLD schema (`template-branch:`); only the pin value was bumped.

## Gates (all PASS)
- `make fmt` — PASS
- `make typecheck` — PASS (ty + mypy --strict, no issues in 10 files)
- `make docs-coverage` — PASS (100.0%)
- `make deptry` — PASS
- `make security` — PASS (pip-audit + bandit, no issues)
- `make test` — PASS (88 passed, 100% coverage)

## Upstream blockers
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)