### PR TITLE
chore: update rhiza to v1.0.0

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.0.0
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.0.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.0.0
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.0.0
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.0.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.0.0
     secrets: inherit

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.0.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -221,7 +221,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.19.9
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.0.0
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.0.0
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_sync.yml
+++ b/.github/workflows/rhiza_sync.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   sync:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v1.0.0
     with:
       direct: ${{ github.event_name == 'push' }}
       create-pr: ${{ github.event_name != 'push' && (github.event_name == 'schedule' || inputs.create-pr == true) }}

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.0.0
     secrets: inherit

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: ff7bd135efaaad8aadf01d41bb60dd8419c015ae
+sha: 3186f09ecffa95a44148fbae02bc90d9e9dd05e2
 repo: jebel-quant/rhiza
 host: github
-ref: v0.19.9
+ref: v1.0.0
 include: []
 exclude: []
 templates:
@@ -107,5 +107,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-06-28T18:08:12Z'
+synced_at: '2026-06-29T13:08:13Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 template-repository: "jebel-quant/rhiza"
-template-branch: "v0.19.9"
+template-branch: "v1.0.0"
 
 profiles:
   - github-project


### PR DESCRIPTION
## Summary
- Bumps the template `template-branch` to `v1.0.0` in `.rhiza/template.yml` (was `v0.19.9`) — **authorized major-version bump**.
- Platform profile: `github-project` (unchanged — origin is `github.com:cvxgrp/simulator`, current profile already matches the detected host).
- Runs `make sync` to apply upstream template changes. **Clean merge — zero conflicts, zero `.rej` files.** 12 files changed: the reusable-workflow `uses:` ref bumped `@v0.19.9` → `@v1.0.0` across 11 `.github/workflows/*` files, plus the `.rhiza/template.lock` hash.

## Quality gates

| Gate | Result |
|------|--------|
| `make fmt` (pre-commit + lint) | PASS — all hooks pass, no auto-format changes |
| `make typecheck` (ty + mypy --strict) | PASS — ty clean; mypy: no issues in 10 source files |
| `make docs-coverage` (interrogate) | PASS — 100.0% (min 100.0%) |
| `make deptry` | PASS — no dependency issues |
| `make security` (pip-audit + bandit) | PASS — no vulnerabilities, no bandit issues |
| `make validate` | PASS — template.yml valid; structure OK |
| `make test` | PASS — 88 passed, coverage 100.0% (min 90%) |

**v1.0.0 breaking-change flag (upstream, not patched here):** under v1.0.0, `make validate` now runs a **full pytest session** (173 passed, 2 skipped) in addition to its structural validation, while `make test` runs its own session (88 passed). The suite therefore executes twice across the two gates. This is an upstream `rhiza_quality`/template concern, flagged per policy — not patched in this PR.

## Scorecard (locally-owned scope: `src/`, `tests/`, `pyproject.toml`, `.rhiza/template.yml`)

| Subcategory | Score | Justification |
|-------------|-------|---------------|
| Linting / style | 10/10 | ruff format + check clean; markdownlint, bandit, actionlint all pass |
| Type safety | 10/10 | ty clean; mypy --strict, no issues in 10 source files |
| Documentation | 10/10 | interrogate 100% (min 100%) |
| Test pass rate | 10/10 | 88 passed, 0 failed |
| Test coverage & depth | 10/10 | 100% line coverage (gate 90%); hypothesis + fuzz + application tests present |
| Dependency & security hygiene | 10/10 | deptry clean; pip-audit no vulns; bandit clean |
| Code structure & readability | 10/10 | small focused `src/` tree, all gates green |
| CI / tooling health | upstream/out-of-scope | 11 Rhiza-owned workflows; `make validate` double-pytest is an upstream v1.0.0 concern |

**Overall: 10/10** for everything this repo locally controls.

**Highest-leverage improvement:** none locally. The single observable wrinkle (validate running the full pytest session, duplicating `make test`) is Rhiza-owned and should be addressed upstream in `jebel-quant/rhiza`, not in this repo.
