### PR TITLE
fix(portfolio): correct Raises docstring and split __post_init__ concerns

### DIFF
--- a/src/cvx/simulator/portfolio.py
+++ b/src/cvx/simulator/portfolio.py
@@ -70,21 +70,34 @@ class Portfolio:
 
         Raises:
         ------
-        AssertionError
+        ValueError
             If any of the validation checks fail
 
         """
-        if not self.prices.index.is_monotonic_increasing:
-            raise ValueError("`prices` index must be monotonic increasing.")  # noqa: TRY003
+        self._validate()
+        self._build_data()
 
-        if not self.prices.index.is_unique:
-            raise ValueError("`prices` index must be unique.")  # noqa: TRY003
+    def _validate(self) -> None:
+        """Validate the prices and units dataframes.
 
-        if not self.units.index.is_monotonic_increasing:
-            raise ValueError("`units` index must be monotonic increasing.")  # noqa: TRY003
+        Checks that both frames have monotonic increasing, unique indices and
+        that the units index and columns are subsets of the prices index and
+        columns respectively.
 
-        if not self.units.index.is_unique:
-            raise ValueError("`units` index must be unique.")  # noqa: TRY003
+        Raises:
+        ------
+        ValueError
+            If any of the validation checks fail
+        """
+        index_checks = (
+            (self.prices.index.is_monotonic_increasing, "`prices` index must be monotonic increasing."),
+            (self.prices.index.is_unique, "`prices` index must be unique."),
+            (self.units.index.is_monotonic_increasing, "`units` index must be monotonic increasing."),
+            (self.units.index.is_unique, "`units` index must be unique."),
+        )
+        for is_valid, message in index_checks:
+            if not is_valid:
+                raise ValueError(message)
 
         missing_dates = self.units.index.difference(self.prices.index)
         if not missing_dates.empty:
@@ -94,6 +107,14 @@ class Portfolio:
         if not missing_assets.empty:
             raise ValueError(f"`units` contains assets not present in `prices`: {missing_assets.tolist()}")  # noqa: TRY003
 
+    def _build_data(self) -> None:
+        """Build and cache the derived quantstats Data from the portfolio NAV.
+
+        This constructs the returns-based :class:`~jquantstats.data.Data` object
+        used by the reporting and statistics helpers and stores it on the frozen
+        instance's ``_data`` field. It is invoked from ``__post_init__`` after
+        the input validation has passed.
+        """
         frame = self.nav.pct_change().to_frame().reset_index()
         frame.columns = ["Date", frame.columns[1]]
         d = Data.from_returns(returns=frame)


### PR DESCRIPTION
Addresses two quality findings in `Portfolio.__post_init__` (`src/cvx/simulator/portfolio.py`).

Closes #779
Closes #780

## #779 — docstring / raises mismatch
`Portfolio.__post_init__` documented `Raises: AssertionError`, but every guard raises `ValueError`. The docstring now documents `ValueError`, so the exception contract matches behaviour. `grep -rn AssertionError src/` returns nothing.

## #780 — separate validation from derived-state construction
`__post_init__` previously mixed six input-validation guards with the `Data.from_returns(...)` derived-state construction. It now orchestrates two focused helpers:

- `_validate()` — the input checks; the four uniform index guards are collapsed into a data-driven loop, the two dynamic-message checks stay explicit.
- `_build_data()` — builds and caches the derived `_data`.

## Verification

| Check | Before | After |
|---|---|---|
| `__post_init__` cyclomatic complexity | B (7) | **A (1)** |
| Worst block in `src/` | B (7) | **A (5)** — no B+ block remains |
| `portfolio.py` maintainability index | 19.25 | **20.34** |
| `make fmt` | — | pass |
| `make typecheck` (ty + mypy --strict) | — | pass |
| `make test` | — | **88 passed, 100% coverage** |

Behaviour is unchanged — same `ValueError` messages and order, still fully covered by the existing `tests/test_portfolio_validation.py` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)