### PR TITLE
fix(fuzzing): bundle scipy into frozen fuzz targets

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -16,6 +16,15 @@ pip3 install .
 # the frozen fuzzer crashes at runtime with
 # "No module named 'numpy._core._exceptions'". --collect-all pulls in every
 # numpy submodule, data file and shared library.
+#
+# scipy needs the same treatment. It is not a direct dependency, but
+# jquantstats 0.10.0 imports it eagerly (_portfolio_cost -> _stats._basic_core),
+# so it is now on cvx.simulator's import path at fuzzer startup. Without
+# --collect-all, PyInstaller misses the compiled scipy._cyutility and the frozen
+# binary dies with "The `scipy` install you are using seems to be broken".
 for fuzzer in tests/fuzz/fuzz_*.py; do
-  compile_python_fuzzer "$fuzzer" --collect-all numpy --collect-all pandas
+  compile_python_fuzzer "$fuzzer" \
+    --collect-all numpy \
+    --collect-all pandas \
+    --collect-all scipy
 done


### PR DESCRIPTION
## Fix ClusterFuzzLite: bundle scipy into the frozen fuzz targets

`fuzzing / ClusterFuzzLite PR fuzzing` started failing with **100% of fuzz
targets broken**. Every frozen target crashed at startup:

```
ModuleNotFoundError: No module named 'scipy._cyutility'
ImportError: The `scipy` install you are using seems to be broken,
             (extension modules cannot be imported), please try reinstalling.
[PYI-158:ERROR] Failed to execute script 'fuzz_interpolation'
```

### Cause

scipy is not a direct dependency of `cvx.simulator` — it arrives transitively
through `jquantstats`, which has required `scipy>=1.14.1` for a long while. What
changed is *when* it gets imported: **jquantstats 0.10.0** (released 2026-07-29)
added `_portfolio_cost.py`, which imports `_stats._basic_core`, which imports
scipy **eagerly at module load**. That put scipy on `cvx.simulator`'s import path
at fuzzer startup for the first time.

`.clusterfuzzlite/build.sh` already collects numpy and pandas explicitly, because
PyInstaller does not discover their C-extension submodules on its own. scipy has
exactly the same problem — PyInstaller's hook misses the compiled
`scipy._cyutility` — but was never listed, since nothing used to import it.

This is why the last green run on `main` was 2026-07-28, the day before the
jquantstats release. **`main` is not actually healthy**; it would fail identically
on its next fuzzing run. The breakage is unrelated to the in-flight rhiza v1.2.5
sync (#797) — that PR's only change to `rhiza_fuzzing.yml` is the pinned ref
`v1.2.2` → `v1.2.5`, and this failure is at the PyInstaller layer, identical
either way.

### Fix

Add `--collect-all scipy` alongside the existing numpy and pandas collection.

### Scope

`.clusterfuzzlite/build.sh` only — a repo-owned file, deliberately kept out of the
template-only sync PR (#797).

### Verification

Docker was not available locally, so this relies on the `fuzzing` check on this
PR. The red baseline is the run on #797 (targets broken with the same resolved
dependency set); this branch should build all targets and run them.
