### PR TITLE
Report coverage from the book, not coveralls

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://badge.fury.io/py/cvxsimulator.svg)](https://badge.fury.io/py/cvxsimulator)
 [![Apache 2.0 License](https://img.shields.io/badge/License-APACHEv2-brightgreen.svg)](https://github.com/cvxgrp/simulator/blob/master/LICENSE)
 [![Downloads](https://static.pepy.tech/personalized-badge/cvxsimulator?period=month&units=international_system&left_color=black&right_color=orange&left_text=PyPI%20downloads%20per%20month)](https://pepy.tech/project/cvxsimulator)
-[![Coverage Status](https://coveralls.io/repos/github/cvxgrp/simulator/badge.png?branch=main)](https://coveralls.io/github/cvxgrp/simulator?branch=main)
+[![Coverage](https://www.cvxgrp.org/simulator/coverage-badge.svg)](https://www.cvxgrp.org/simulator/reports/html-coverage/)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://github.com/renovatebot/renovate)
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/cvxgrp/simulator)


### PR DESCRIPTION
The README pointed at coveralls, whose last calculation for this repo is `2025-07-22` — over a year stale, and unrelated to what CI measures now. Meanwhile `rhiza_book.yml` has been publishing a fresh badge and full HTML report to Pages on every push to `main` all along; nothing linked to them.

This points the badge at what the book already publishes:

- `https://www.cvxgrp.org/simulator/coverage-badge.svg` → `200`, currently `100.00%`
- `https://www.cvxgrp.org/simulator/reports/html-coverage/` → `200`

Same form as `cvxrisk`, `cvxcla` and `jquantstats`. No workflow change is needed — coveralls was referenced only in the README, never uploaded to by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)