### PR TITLE
fix: enforce 100% coverage and document the test-layout opt-out

### DIFF
--- a/.rhiza/.env
+++ b/.rhiza/.env
@@ -11,3 +11,8 @@
 MARIMO_FOLDER=docs/notebooks
 SOURCE_FOLDER=src
 RHIZA_CI_OS_MATRIX=["ubuntu-latest","macos-latest","windows-latest"]
+# Raised from the rhiza default of 90. The suite already covers every statement
+# in src/, and [tool.check_test_layout] in pyproject.toml cites this gate as the
+# guarantee that replaces 1:1 test/source mirroring — so the bar has to be the
+# one that actually holds, not one the repo happens to clear.
+COVERAGE_FAIL_UNDER=100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,18 @@ DEP002 = ["pyarrow", "pytest"]
 [tool.mypy]
 ignore_missing_imports = true
 
+# Tests here are grouped by the behaviour they exercise, not by the module they
+# import: interpolation splits into happy-path/error cases, and the portfolio
+# and state suites each pair a behavioural file with a validation file. A 1:1
+# tests/cvx/simulator/test_<module>.py mirror would scatter those groupings
+# across the package tree without verifying anything more. What the mirror is
+# there to guarantee — that no module drifts loose from its tests — is instead
+# guaranteed by COVERAGE_FAIL_UNDER=100 in .rhiza/.env, which fails the build if
+# any statement in src/ goes uncovered.
+[tool.check_test_layout]
+enforce = false
+reason = "Tests are grouped by behaviour rather than mirroring source modules; per-module coverage is guaranteed instead by the 100% COVERAGE_FAIL_UNDER gate in .rhiza/.env."
+
 # bump-my-version only auto-discovers .bumpversion.toml, .bumpversion.cfg,
 # setup.cfg and pyproject.toml. Without a table here it falls back to
 # `git describe`, so a release can be cut at an already-published version.


### PR DESCRIPTION
## Summary

`check_test_layout.py` exited 1 with 25 violations. This declares the checker's
documented opt-out — and raises the coverage bar to 100% so that the guarantee the
opt-out cites is actually enforced rather than merely met by coincidence.

Closes #809

## Changes

- **`pyproject.toml`** — add `[tool.check_test_layout]` with `enforce = false` and a
  `reason` recording why: tests are grouped by the behaviour they exercise, not by the
  module they import.
- **`.rhiza/.env`** — add `COVERAGE_FAIL_UNDER=100`, raising it from rhiza's default of 90.

## Why not restructure the tests instead?

The 25 violations break down as 5 source modules with no path-mirrored test file and 20
test files with no source counterpart. That is a naming/nesting mismatch, not missing
tests: the package lives at `src/cvx/simulator/` while the tests sit flat under `tests/`,
and coverage was already 100% with zero missed statements. Moving 20 working test files
into `tests/cvx/simulator/…` would close the same gap at considerably higher cost while
verifying nothing more, and would scatter groupings that currently pair a behavioural
file with a validation file (`test_portfolio.py` / `test_portfolio_validation.py`, and the
same for state).

## Why the coverage raise is the substantive half

The opt-out is only honest because the guarantee it names is now enforced. Before this,
the repo *happened* to sit at 100% against a 90% bar — so a future PR could have dropped a
module's coverage without failing anything, while `[tool.check_test_layout]` still pointed
at coverage as the safeguard that replaces mirroring. Raising the bar to 100 is what makes
the stated `reason` true rather than aspirational. This is the change most worth reviewing:
it means any future PR that leaves a statement in `src/` uncovered now fails CI.

## Note on `.rhiza/.env`

That file is listed in `.rhiza/template.lock`, so it is template-delivered — but it is the
designated override file (its header reads *"Add or uncomment only the variables you want
to override"*), and the repo's three existing overrides survived the sync to v1.3.3. So
this is the intended mechanism, not a local patch that `/rhiza:update` will clobber.

## Testing

- [x] `make test` passes locally — 89 passed, `Required test coverage of 100% reached. Total coverage: 100.00%`
- [x] `make fmt` has been run — all 21 hooks pass, including `Validate pyproject.toml` and `Check rhiza configuration`
- [x] New tests added (or explain why not needed) — not needed; this is config only, and the existing suite is what the change is asserting about. Verified directly: `check_test_layout.py` now exits 0 with *"Test layout OK: parity not enforced by request"*.

## Checklist

- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `CHANGELOG.md` entry added (or not needed for this change) — not needed; no user-facing behaviour change, and the changelog is generated from conventional commits via `cliff.toml`
- [x] Documentation updated if behaviour changed — the rationale is recorded inline in both files
- [x] `make deps` passes (no unused or missing dependencies) — verified via `make deptry`, no dependency issues

## Related

#812 proposes consolidating the four `tests/test_utils/test_interpolation*.py` modules,
which are currently named for the coverage they chase rather than the behaviour they
assert. That would strengthen the "grouped by behaviour" claim this PR's `reason` now
makes — worth landing after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
