### PR TITLE
docs: add runnable examples to the public API and run doctests in CI

### DIFF
--- a/src/cvx/simulator/_analytics.py
+++ b/src/cvx/simulator/_analytics.py
@@ -38,6 +38,33 @@ class PortfolioAnalytics:
     :class:`jquantstats.data.Data` object (in :meth:`_build_data`) and exposes
     the ``stats``/``plots``/``reports`` surface plus the :meth:`sharpe` and
     :meth:`snapshot` convenience helpers on top of it.
+
+    Examples:
+    --------
+    The mixin is not used directly — :class:`~cvx.simulator.portfolio.Portfolio`
+    inherits it, so every portfolio carries the analytics surface:
+
+    >>> import pandas as pd
+    >>> from cvx.simulator import Portfolio
+    >>> from cvx.simulator._analytics import PortfolioAnalytics
+    >>> issubclass(Portfolio, PortfolioAnalytics)
+    True
+
+    >>> dates = pd.date_range("2020-01-01", periods=4)
+    >>> prices = pd.DataFrame(
+    ...     {"A": [100.0, 102.0, 104.0, 103.0], "B": [50.0, 51.0, 52.0, 51.0]},
+    ...     index=dates,
+    ... )
+    >>> units = pd.DataFrame({"A": [5.0] * 4, "B": [10.0] * 4}, index=dates)
+    >>> portfolio = Portfolio(prices=prices, units=units, aum=1000.0)
+
+    All of it is derived from the NAV alone:
+
+    >>> portfolio.nav.tolist()
+    [1000.0, 1020.0, 1040.0, 1025.0]
+    >>> sorted(m for m in ("stats", "plots", "reports") if hasattr(portfolio, m))
+    ['plots', 'reports', 'stats']
+
     """
 
     if TYPE_CHECKING:
@@ -146,6 +173,33 @@ class PortfolioAnalytics:
         -----
         The Sharpe ratio is calculated using the portfolio's NAV time series.
         A higher Sharpe ratio indicates better risk-adjusted performance.
+
+        Examples:
+        --------
+        >>> import pandas as pd
+        >>> from cvx.simulator import Portfolio
+        >>> dates = pd.date_range("2020-01-01", periods=4)
+        >>> prices = pd.DataFrame(
+        ...     {"A": [100.0, 102.0, 104.0, 103.0], "B": [50.0, 51.0, 52.0, 51.0]},
+        ...     index=dates,
+        ... )
+        >>> units = pd.DataFrame({"A": [5.0] * 4, "B": [10.0] * 4}, index=dates)
+        >>> portfolio = Portfolio(prices=prices, units=units, aum=1000.0)
+
+        Without ``periods`` the ratio is left unannualized:
+
+        >>> round(portfolio.sharpe(), 2)
+        8.12
+
+        Passing the number of periods per year annualizes it — 252 for daily
+        data, 52 for weekly, 12 for monthly:
+
+        >>> round(portfolio.sharpe(periods=252), 2)
+        6.74
+
+        Both numbers are meaningless as investment results: three returns is far
+        too short a sample to say anything about risk-adjusted performance. They
+        demonstrate the call, not a realistic figure.
 
         """
         return float(self.stats.sharpe(periods=periods)["NAV"])

--- a/src/cvx/simulator/builder.py
+++ b/src/cvx/simulator/builder.py
@@ -58,6 +58,39 @@ class Builder:
 
     After the iteration has been completed we build a Portfolio object
     by calling the build method.
+
+    Examples:
+    --------
+    Load the prices, then iterate. Each step yields the timestamps seen so far
+    and the current state; assigning to the builder records that day's position.
+
+    >>> import pandas as pd
+    >>> from cvx.simulator import Builder
+    >>> dates = pd.date_range("2020-01-01", periods=4)
+    >>> prices = pd.DataFrame(
+    ...     {"A": [100.0, 102.0, 104.0, 103.0], "B": [50.0, 51.0, 52.0, 51.0]},
+    ...     index=dates,
+    ... )
+    >>> builder = Builder(prices=prices, initial_aum=1000.0)
+    >>> for t, state in builder:
+    ...     builder.position = pd.Series({"A": 5.0, "B": 4.0})
+    ...     builder.aum = state.aum
+
+    The AUM series tracks the value of the book as prices move:
+
+    >>> builder.aum
+    2020-01-01    1000.0
+    2020-01-02    1014.0
+    2020-01-03    1028.0
+    2020-01-04    1019.0
+    Freq: D, dtype: float64
+
+    Once the loop is done, freeze the result into a Portfolio:
+
+    >>> portfolio = builder.build()
+    >>> type(portfolio).__name__
+    'Portfolio'
+
     """
 
     prices: pd.DataFrame
@@ -319,6 +352,35 @@ class Builder:
         have the same data as the Builder from which it was built, but
         with a different interface focused on analysis rather than construction.
 
+        Examples:
+        --------
+        >>> import pandas as pd
+        >>> from cvx.simulator import Builder
+        >>> dates = pd.date_range("2020-01-01", periods=4)
+        >>> prices = pd.DataFrame(
+        ...     {"A": [100.0, 102.0, 104.0, 103.0], "B": [50.0, 51.0, 52.0, 51.0]},
+        ...     index=dates,
+        ... )
+        >>> builder = Builder(prices=prices, initial_aum=1000.0)
+        >>> for t, state in builder:
+        ...     builder.position = pd.Series({"A": 5.0, "B": 4.0})
+        ...     builder.aum = state.aum
+        >>> portfolio = builder.build()
+
+        The portfolio carries the units the loop accumulated:
+
+        >>> portfolio.units.iloc[-1]
+        A    5.0
+        B    4.0
+        Name: 2020-01-04 00:00:00, dtype: float64
+
+        The result is frozen — analysis only, no further construction:
+
+        >>> portfolio.aum = 10.0
+        Traceback (most recent call last):
+            ...
+        dataclasses.FrozenInstanceError: cannot assign to field 'aum'
+
         """
         return Portfolio(prices=self.prices, units=self.units, aum=self.aum)
 
@@ -364,6 +426,30 @@ class Builder:
         This is a convenient way to rebalance the portfolio by specifying
         the desired allocation as weights rather than exact positions.
         The conversion formula is: position = NAV * weights / prices
+
+        Examples:
+        --------
+        Hold an equal-weighted book, rebalanced every day. The weights are
+        constant, so the units drift as the relative prices move:
+
+        >>> import numpy as np
+        >>> import pandas as pd
+        >>> from cvx.simulator import Builder
+        >>> dates = pd.date_range("2020-01-01", periods=4)
+        >>> prices = pd.DataFrame(
+        ...     {"A": [100.0, 102.0, 104.0, 103.0], "B": [50.0, 51.0, 52.0, 51.0]},
+        ...     index=dates,
+        ... )
+        >>> builder = Builder(prices=prices, initial_aum=1000.0)
+        >>> for t, state in builder:
+        ...     builder.weights = np.array([0.5, 0.5])
+        ...     builder.aum = state.aum
+        >>> builder.units.round(4)
+                       A        B
+        2020-01-01  5.00  10.0000
+        2020-01-02  5.00  10.0000
+        2020-01-03  5.00  10.0000
+        2020-01-04  4.90   9.8971
 
         """
         self.position = self._state.nav * weights / self.current_prices

--- a/src/cvx/simulator/portfolio.py
+++ b/src/cvx/simulator/portfolio.py
@@ -51,6 +51,45 @@ class Portfolio(PortfolioAnalytics):
     aum : Union[float, pd.Series]
         Assets under management, either as a constant float or as a Series over time
 
+    Examples:
+    --------
+    A portfolio is usually produced by :meth:`Builder.build`, but it can be
+    constructed directly from prices, units and a starting AUM:
+
+    >>> import pandas as pd
+    >>> from cvx.simulator import Portfolio
+    >>> dates = pd.date_range("2020-01-01", periods=4)
+    >>> prices = pd.DataFrame(
+    ...     {"A": [100.0, 102.0, 104.0, 103.0], "B": [50.0, 51.0, 52.0, 51.0]},
+    ...     index=dates,
+    ... )
+    >>> units = pd.DataFrame({"A": [5.0] * 4, "B": [10.0] * 4}, index=dates)
+    >>> portfolio = Portfolio(prices=prices, units=units, aum=1000.0)
+    >>> portfolio.assets
+    ['A', 'B']
+
+    The cash value of each holding, and the NAV it rolls up to:
+
+    >>> portfolio.cashposition
+                    A      B
+    2020-01-01  500.0  500.0
+    2020-01-02  510.0  510.0
+    2020-01-03  520.0  520.0
+    2020-01-04  515.0  510.0
+    >>> portfolio.nav
+    2020-01-01    1000.0
+    2020-01-02    1020.0
+    2020-01-03    1040.0
+    2020-01-04    1025.0
+    Freq: D, Name: NAV, dtype: float64
+
+    The object is frozen, so analysis can never mutate the record:
+
+    >>> portfolio.aum = 2000.0
+    Traceback (most recent call last):
+        ...
+    dataclasses.FrozenInstanceError: cannot assign to field 'aum'
+
     """
 
     prices: pd.DataFrame
@@ -161,6 +200,38 @@ class Portfolio(PortfolioAnalytics):
         pd.Series
             Series representing the NAV of the portfolio over time
 
+        Examples:
+        --------
+        >>> import pandas as pd
+        >>> from cvx.simulator import Portfolio
+        >>> dates = pd.date_range("2020-01-01", periods=4)
+        >>> prices = pd.DataFrame(
+        ...     {"A": [100.0, 102.0, 104.0, 103.0], "B": [50.0, 51.0, 52.0, 51.0]},
+        ...     index=dates,
+        ... )
+        >>> units = pd.DataFrame({"A": [5.0] * 4, "B": [10.0] * 4}, index=dates)
+
+        Passing a scalar ``aum`` makes the NAV the cumulative profit on top of it:
+
+        >>> Portfolio(prices=prices, units=units, aum=1000.0).nav
+        2020-01-01    1000.0
+        2020-01-02    1020.0
+        2020-01-03    1040.0
+        2020-01-04    1025.0
+        Freq: D, Name: NAV, dtype: float64
+
+        Passing a Series instead uses it verbatim — which is what
+        :meth:`Builder.build` does, so a strategy that adds or withdraws capital
+        is recorded rather than inferred:
+
+        >>> aum = pd.Series([1000.0, 1100.0, 1200.0, 1300.0], index=dates)
+        >>> Portfolio(prices=prices, units=units, aum=aum).nav
+        2020-01-01    1000.0
+        2020-01-02    1100.0
+        2020-01-03    1200.0
+        2020-01-04    1300.0
+        Freq: D, Name: NAV, dtype: float64
+
         """
         if isinstance(self.aum, pd.Series):
             series = self.aum
@@ -188,6 +259,32 @@ class Portfolio(PortfolioAnalytics):
         The profit is calculated by multiplying the previous day's positions
         (in currency terms) by the returns of each asset, and then summing
         across all assets.
+
+        Examples:
+        --------
+        >>> import pandas as pd
+        >>> from cvx.simulator import Portfolio
+        >>> dates = pd.date_range("2020-01-01", periods=4)
+        >>> prices = pd.DataFrame(
+        ...     {"A": [100.0, 102.0, 104.0, 103.0], "B": [50.0, 51.0, 52.0, 51.0]},
+        ...     index=dates,
+        ... )
+        >>> units = pd.DataFrame({"A": [5.0] * 4, "B": [10.0] * 4}, index=dates)
+        >>> portfolio = Portfolio(prices=prices, units=units, aum=1000.0)
+
+        The first day has no previous position, so it books no profit:
+
+        >>> portfolio.profit
+        2020-01-01     0.0
+        2020-01-02    20.0
+        2020-01-03    20.0
+        2020-01-04   -15.0
+        Freq: D, Name: Profit, dtype: float64
+
+        Cumulating the profit onto the starting AUM reproduces the NAV:
+
+        >>> (portfolio.profit.cumsum() + 1000.0).equals(portfolio.nav.rename("Profit"))
+        True
 
         """
         series = (self.cashposition.shift(1) * self.returns.fillna(0.0)).sum(axis=1)
@@ -341,10 +438,34 @@ class Portfolio(PortfolioAnalytics):
 
         Examples:
         --------
-        ```
-        portfolio['2023-01-01']  # Get positions on January 1, 2023
-        portfolio[pd.Timestamp('2023-01-01')]  # Same as above
-        ```
+        >>> import pandas as pd
+        >>> from cvx.simulator import Portfolio
+        >>> dates = pd.date_range("2020-01-01", periods=4)
+        >>> prices = pd.DataFrame(
+        ...     {"A": [100.0, 102.0, 104.0, 103.0], "B": [50.0, 51.0, 52.0, 51.0]},
+        ...     index=dates,
+        ... )
+        >>> units = pd.DataFrame({"A": [5.0] * 4, "B": [10.0] * 4}, index=dates)
+        >>> portfolio = Portfolio(prices=prices, units=units, aum=1000.0)
+
+        Index with a string or a Timestamp — both reach the same row:
+
+        >>> portfolio["2020-01-02"]
+        A     5.0
+        B    10.0
+        Name: 2020-01-02 00:00:00, dtype: float64
+        >>> portfolio[pd.Timestamp("2020-01-02")].equals(portfolio["2020-01-02"])
+        True
+
+        A date outside the index raises. (Caught here rather than shown as a
+        traceback: pandas chains several exceptions on the way out, and the
+        intermediate frames are an implementation detail, not a contract.)
+
+        >>> try:
+        ...     portfolio["2021-01-01"]
+        ... except KeyError as err:
+        ...     print(err)
+        '2021-01-01'
 
         """
         return self.units.loc[time]
@@ -391,6 +512,32 @@ class Portfolio(PortfolioAnalytics):
         for a fully invested portfolio with no leverage. Weights can be negative
         for short positions.
 
+        Examples:
+        --------
+        >>> import pandas as pd
+        >>> from cvx.simulator import Portfolio
+        >>> dates = pd.date_range("2020-01-01", periods=4)
+        >>> prices = pd.DataFrame(
+        ...     {"A": [100.0, 102.0, 104.0, 103.0], "B": [50.0, 51.0, 52.0, 51.0]},
+        ...     index=dates,
+        ... )
+        >>> units = pd.DataFrame({"A": [5.0] * 4, "B": [10.0] * 4}, index=dates)
+        >>> portfolio = Portfolio(prices=prices, units=units, aum=1000.0)
+
+        Holding the units fixed, the weights drift with the relative prices:
+
+        >>> portfolio.weights.round(4)
+                         A       B
+        2020-01-01  0.5000  0.5000
+        2020-01-02  0.5000  0.5000
+        2020-01-03  0.5000  0.5000
+        2020-01-04  0.5024  0.4976
+
+        This book is fully invested, so each row sums to 1.0:
+
+        >>> portfolio.weights.sum(axis=1).round(6).unique().tolist()
+        [1.0]
+
         """
         return self.equity.apply(lambda x: x / self.nav)
 
@@ -420,6 +567,31 @@ class Portfolio(PortfolioAnalytics):
         The units are calculated by dividing the cash positions by the prices.
         This is useful when you have the monetary value of each position rather
         than the number of units.
+
+        Examples:
+        --------
+        Specify the book in currency rather than units — 500 in each name:
+
+        >>> import pandas as pd
+        >>> from cvx.simulator import Portfolio
+        >>> dates = pd.date_range("2020-01-01", periods=4)
+        >>> prices = pd.DataFrame(
+        ...     {"A": [100.0, 102.0, 104.0, 103.0], "B": [50.0, 51.0, 52.0, 51.0]},
+        ...     index=dates,
+        ... )
+        >>> cashposition = pd.DataFrame({"A": [500.0] * 4, "B": [500.0] * 4}, index=dates)
+        >>> portfolio = Portfolio.from_cashpos_prices(
+        ...     prices=prices, cashposition=cashposition, aum=1000.0
+        ... )
+
+        The units are the cash amounts divided by the prices:
+
+        >>> portfolio.units.round(4)
+                         A        B
+        2020-01-01  5.0000  10.0000
+        2020-01-02  4.9020   9.8039
+        2020-01-03  4.8077   9.6154
+        2020-01-04  4.8544   9.8039
 
         """
         units = cashposition.div(prices, fill_value=0.0)

--- a/src/cvx/simulator/state.py
+++ b/src/cvx/simulator/state.py
@@ -54,6 +54,37 @@ class State:
     _aum : float
         Current assets under management (AUM) of the portfolio
 
+    Examples:
+    --------
+    A state starts empty and is filled in by assignment. Order matters: prices
+    define which assets exist, so they are set before any position.
+
+    >>> import pandas as pd
+    >>> from cvx.simulator import State
+    >>> state = State()
+    >>> state.aum = 1000.0
+    >>> state.prices = pd.Series({"A": 100.0, "B": 50.0})
+    >>> state.position = pd.Series({"A": 5.0, "B": 4.0})
+
+    The derived quantities follow from those three assignments:
+
+    >>> state.cashposition
+    A    500.0
+    B    200.0
+    dtype: float64
+    >>> state.value
+    700.0
+    >>> float(state.cash)
+    300.0
+
+    Updating the prices books the profit and moves the AUM with it:
+
+    >>> state.prices = pd.Series({"A": 110.0, "B": 50.0})
+    >>> float(state.profit)
+    50.0
+    >>> float(state.nav)
+    1050.0
+
     """
 
     _prices: pd.Series | None = None
@@ -73,6 +104,25 @@ class State:
         float
             The cash component of the portfolio, calculated as NAV minus
             the value of all positions
+
+        Examples:
+        --------
+        >>> import pandas as pd
+        >>> from cvx.simulator import State
+        >>> state = State()
+        >>> state.aum = 1000.0
+        >>> state.prices = pd.Series({"A": 100.0, "B": 50.0})
+
+        With nothing invested the whole AUM is cash:
+
+        >>> float(state.cash)
+        1000.0
+
+        Buying 700 of stock moves that amount out of cash:
+
+        >>> state.position = pd.Series({"A": 5.0, "B": 4.0})
+        >>> float(state.cash)
+        300.0
 
         """
         return self.nav - self.value
@@ -157,6 +207,32 @@ class State:
             Series with the number of units held for each asset, indexed by asset.
             If the position is not yet set, returns an empty series with the
             correct index.
+
+        Examples:
+        --------
+        Before anything is bought the position carries the assets, but no units:
+
+        >>> import pandas as pd
+        >>> from cvx.simulator import State
+        >>> state = State()
+        >>> state.aum = 1000.0
+        >>> state.prices = pd.Series({"A": 100.0, "B": 50.0})
+        >>> state.position
+        A   NaN
+        B   NaN
+        dtype: float64
+
+        Assigning a position also records the trades needed to reach it:
+
+        >>> state.position = pd.Series({"A": 5.0, "B": 4.0})
+        >>> state.position
+        A    5.0
+        B    4.0
+        dtype: float64
+        >>> state.trades
+        A    5.0
+        B    4.0
+        dtype: float64
 
         """
         if self._position is None:
@@ -401,6 +477,25 @@ class State:
         If positions are missing, a series of zeros is effectively returned.
         The sum of weights equals 1.0 for a fully invested portfolio with no leverage.
 
+        Examples:
+        --------
+        >>> import pandas as pd
+        >>> from cvx.simulator import State
+        >>> state = State()
+        >>> state.aum = 1000.0
+        >>> state.prices = pd.Series({"A": 100.0, "B": 50.0})
+        >>> state.position = pd.Series({"A": 5.0, "B": 4.0})
+
+        The weights are fractions of NAV, so they sum to less than 1.0 here —
+        the remaining 0.3 is the uninvested cash:
+
+        >>> state.weights
+        A    0.5
+        B    0.2
+        dtype: float64
+        >>> float(state.weights.sum())
+        0.7
+
         """
         if not np.isclose(self.nav, self.aum):
             msg = f"{self.nav} != {self.aum}"
@@ -426,6 +521,26 @@ class State:
         A leverage of 2.0 means the portfolio has twice the market exposure
         compared to its net asset value, which could be achieved through
         borrowing or short selling.
+
+        Examples:
+        --------
+        A long 1000 / short 500 book on a NAV of 1000. The net exposure is only
+        500, but the leverage counts both legs:
+
+        >>> import pandas as pd
+        >>> from cvx.simulator import State
+        >>> state = State()
+        >>> state.aum = 1000.0
+        >>> state.prices = pd.Series({"A": 100.0, "B": 50.0})
+        >>> state.position = pd.Series({"A": 10.0, "B": -10.0})
+        >>> state.weights
+        A    1.0
+        B   -0.5
+        dtype: float64
+        >>> state.leverage
+        1.5
+        >>> state.gmv
+        1500.0
 
         """
         return float(self.weights.abs().sum())

--- a/src/cvx/simulator/utils/interpolation.py
+++ b/src/cvx/simulator/utils/interpolation.py
@@ -142,7 +142,7 @@ def interpolate_pl(ts: pl.Series) -> pl.Series:
     --------
     >>> import polars as pl
     >>> ts = pl.Series([1, None, None, 4, 5])
-    >>> interpolate_pl(ts)
+    >>> interpolate_pl(ts)  # doctest: +NORMALIZE_WHITESPACE
     shape: (5,)
     Series: '' [i64]
     [

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -1,0 +1,77 @@
+"""Execute every doctest in the package as part of the ordinary test run.
+
+Without this, the ``>>>`` examples in the public API are documentation that
+nothing verifies: ``interrogate`` only asks whether a docstring exists, and
+``make test`` collects ``tests/`` alone. That gap is not hypothetical — the
+polars example in ``interpolate_pl`` had drifted from what the function
+actually renders, and stayed that way because no gate ever ran it.
+
+Modules are discovered rather than listed, so a new module's examples are
+covered the day it is added.
+"""
+
+import contextlib
+import doctest
+import importlib
+import io
+import pkgutil
+
+import pytest
+
+import cvx.simulator
+
+
+def _modules() -> list[str]:
+    """Return the import paths of every module in the cvx.simulator package.
+
+    Returns:
+    -------
+    list[str]
+        Dotted module paths, including the package root itself.
+
+    """
+    names = [cvx.simulator.__name__]
+    names.extend(info.name for info in pkgutil.walk_packages(cvx.simulator.__path__, prefix="cvx.simulator."))
+    return sorted(names)
+
+
+@pytest.mark.parametrize("module_name", _modules())
+def test_doctests(module_name: str) -> None:
+    """Run the doctests of a single module and fail with the offending diff.
+
+    Parameters
+    ----------
+    module_name : str
+        Dotted path of the module whose docstrings should be executed.
+
+    """
+    module = importlib.import_module(module_name)
+
+    # doctest reports failures to stdout; capture it so the assertion message
+    # carries the expected/got diff rather than just a count.
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        result = doctest.testmod(module, verbose=False)
+
+    assert result.failed == 0, f"{module_name}: {result.failed} doctest failure(s)\n\n{buffer.getvalue()}"
+
+
+def test_public_api_carries_examples() -> None:
+    """Every name exported from cvx.simulator must document a runnable example.
+
+    Guards the gap this suite was added to close: a class can hold a perfect
+    docstring, score 100% on interrogate, and still show the reader nothing
+    they can run.
+    """
+    parser = doctest.DocTestParser()
+    missing = []
+
+    for name in cvx.simulator.__all__:
+        obj = getattr(cvx.simulator, name)
+        if not (isinstance(obj, type) or callable(obj)):
+            continue  # __version__ and friends carry no docstring of their own
+        docstring = obj.__doc__ or ""
+        if not parser.get_examples(docstring):
+            missing.append(name)
+
+    assert not missing, f"exported names without a doctest example: {missing}"


### PR DESCRIPTION
## Summary

Docstring coverage was already 100%, but all 26 doctest examples in the package lived in
`utils/interpolation.py`. `Builder`, `Portfolio`, `State` and `PortfolioAnalytics` — every
name in `__all__` — documented no example anyone could run. This adds them, and wires
doctests into `make test` so they stay true.

Closes #810

## Changes

- **Examples on the public API** — class docstrings plus the members that carry the most
  meaning: `State.{cash,position,weights,leverage}`, `Builder.{build,weights}`,
  `Portfolio.{nav,profit,weights,__getitem__,from_cashpos_prices}` and
  `PortfolioAnalytics.sharpe`. All share one small fixture (two assets, four days) chosen
  so the arithmetic stays legible — NAV `1000 / 1020 / 1040 / 1025`.
- **`tests/test_doctests.py`** — runs every module's doctests as part of the ordinary
  suite, and guards that each name in `__all__` carries at least one example.
- **Two documentation bugs fixed** (below).

Inventory goes from **26 examples in 1 module** to **166 across 22 objects in all 5**.

## Two bugs found by actually running the examples

**1. `Portfolio.__getitem__` had a fake example.** It carried an `Examples:` block inside a
plain ``` fence — never executable — and it referenced `portfolio['2023-01-01']`, a date
the surrounding example never defines. Now a real doctest.

**2. `interpolate_pl`'s polars example was wrong and had never passed.** It expects
space-indented output where polars renders **tabs**:

```
Expected:            Got:
[                    [
    1                →   1        (tab)
    1                →   1
```

Marked `+NORMALIZE_WHITESPACE` rather than pinning tabs, since the indent character is
polars' formatting detail rather than a contract — pinning it would just break again on the
next polars bump.

## Why the new test file, and not just the examples

The second bug is the argument for `tests/test_doctests.py`. **Nothing ran doctests.**
`interrogate` only asks whether a docstring *exists*; `make test` collects `tests/` alone,
and `pytest.ini` is template-owned so `--doctest-modules` is not this repo's to set. A
documented example could therefore be wrong indefinitely — and one was.

The suite discovers modules via `pkgutil.walk_packages` rather than listing them, so a new
module's examples are covered the day it is added, and failures report the expected/got
diff rather than just a count.

## One thing documented as found rather than fixed

Examples show `float(state.cash)` rather than `state.cash`, because `cash`, `nav` and
`profit` are annotated `-> float` but actually return `np.float64` — unlike `value`, `gmv`
and `leverage`, which coerce explicitly. Rather than quietly hide it behind a `round()`, the
examples are honest about it. **Fixing the annotation mismatch is out of scope here** — it is
a (small) behaviour change and this PR is documentation. Happy to file it separately.

## Testing

- [x] `make test` passes locally — **97 passed** (was 89), coverage still **100.00%**
- [x] `make fmt` has been run — all 21 hooks pass
- [x] New tests added — `tests/test_doctests.py`, 8 cases
- [x] `make typecheck` — `ty` clean, `mypy --strict` clean on 7 files
- [x] `make deps` passes — no dependency issues

The issue's own acceptance criterion, run in the project environment (not `--no-project`,
where imports are unmeasurable):

```
check_doc_examples.py --source-root src --run
→ exit 0, attempted=158 failed=0 unimportable=0
```

## Checklist

- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `CHANGELOG.md` entry added (or not needed) — not needed; generated from conventional commits via `cliff.toml`
- [x] Documentation updated if behaviour changed — no behaviour change; this *is* the documentation change
- [x] `make deps` passes

## Note on ordering

`tests/test_doctests.py` is one more orphan for `check_test_layout.py`, which already fails
on `main` with 25 violations — so this adds no new breakage, and #814 turns that enforcement
off. Either merge order works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
