### PR TITLE
docs: describe the cvx.simulator package as it actually is

### DIFF
--- a/src/cvx/simulator/__init__.py
+++ b/src/cvx/simulator/__init__.py
@@ -1,9 +1,19 @@
-"""Compatibility shim for cvx.simulator.
+"""Public API of the cvxsimulator distribution, importable as `cvx.simulator`.
 
-This subpackage provides a stable import path `cvx.simulator` for tests and
-examples. It re-exports the primary public API from the parent `cvx` package
-and exposes submodules so that imports like `from cvx.simulator.builder import ...`
-continue to work.
+The package exposes the three objects a backtest is built from:
+
+- `Builder` accumulates positions while iterating over a frame of prices;
+- `Portfolio` holds the finished result and the analytics derived from it;
+- `State` is the view of the book at a single point in time, handed to the
+  caller on each step of the builder's loop.
+
+Alongside them sit the `interpolate` and `valid` price helpers from
+`cvx.simulator.utils`. Submodules stay importable directly, so
+`from cvx.simulator.builder import Builder` reaches the same class as
+`from cvx.simulator import Builder`.
+
+`__version__` is resolved at import time from the installed distribution
+metadata of `cvxsimulator`.
 """
 
 import importlib.metadata


### PR DESCRIPTION
## Summary

The `cvx.simulator` package docstring described a structure that does not exist. It is
now accurate.

Closes #813

## Changes

- `src/cvx/simulator/__init__.py` — rewrite the module docstring.

## What was wrong

The docstring opened *"Compatibility shim for cvx.simulator … It re-exports the primary
public API from the parent `cvx` package."* Three claims, none of them true:

1. **Not a shim.** `pyproject.toml` declares `packages = ["src/cvx"]`, and `cvx.simulator`
   is the only importable module tree the wheel ships.
2. **No parent package.** `src/cvx/` contains no `__init__.py` — it is an implicit
   namespace package with nothing in it to re-export.
3. **The imports contradict the prose.** Lines 14-18 import from `.builder`, `.portfolio`,
   `.state` and `.utils` — the module's own submodules, not any parent.

## Why it mattered

This is the failure mode with the longest half-life in a repo: the docstring renders
perfectly, `interrogate` scores it 100% because a docstring *exists*, and no gate asks
whether what it claims is still true. "Compatibility shim" was the costly phrase — it
invites a reader orienting themselves to skip the file as legacy scaffolding, when it is
in fact the public API surface.

## Testing

- [x] `make test` — 89 passed, coverage 100.00%
- [x] `make fmt` — all 21 hooks pass, including `interrogate`
- [x] New tests added — not needed; docstring prose only, no behaviour change

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `CHANGELOG.md` entry — not needed; generated from conventional commits via `cliff.toml`
- [x] Documentation updated if behaviour changed — this *is* the documentation change
- [x] `make deps` passes — untouched by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)