### PR TITLE
chore: update rhiza to v1.6.0

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.6.0
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.6.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.6.0
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.6.0
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.6.0
     secrets: inherit

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.6.0
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.6.0
     secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
         groups: ["lint", "fast"]
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: 0.26
+    rev: "0.26"
     hooks:
       - id: validate-pyproject
         groups: ["python", "fast"]

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,13 +1,10 @@
-sha: 8ef5b50907aaf9c29aaf24c8c8de34a015f486a6
+sha: e556617285b215566e563c58022c3a031e870aad
 repo: jebel-quant/rhiza
 host: github
-ref: v1.5.0
+ref: v1.6.0
 include: []
 exclude:
-- .github/workflows/rhiza_mutation.yml
 - .github/CONFIG.md
-- .github/DISCUSSION_TEMPLATE
-- .github/ISSUE_TEMPLATE
 templates:
 - legal
 profiles:
@@ -46,5 +43,5 @@ files:
 - pytest.ini
 - ruff.toml
 - tests/test_rhiza_packaging.py
-synced_at: '2026-08-22T11:30:18Z'
+synced_at: '2026-08-25T07:21:40Z'
 strategy: merge

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -5,6 +5,7 @@ ref: v1.6.0
 include: []
 exclude:
 - .github/CONFIG.md
+- SECURITY.md
 templates:
 - legal
 profiles:
@@ -33,7 +34,6 @@ files:
 - .rhiza/semgrep.yml
 - LICENSE
 - Makefile
-- SECURITY.md
 - cliff.toml
 - docs/assets/rhiza-logo.svg
 - docs/development/MARIMO.md
@@ -43,5 +43,5 @@ files:
 - pytest.ini
 - ruff.toml
 - tests/test_rhiza_packaging.py
-synced_at: '2026-08-25T07:21:40Z'
+synced_at: '2026-08-25T07:27:19Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v1.5.0"
+ref: "v1.6.0"
 
 profiles:
   - github-project

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -17,3 +17,10 @@ exclude:
   # up rather than to anyone reading the tree. Upstream is where it belongs.
   - .github/CONFIG.md
 
+  # SECURITY.md. The template's copy enumerates security measures generically;
+  # the accurate list differs per repo, so this one is maintained here. Excluding
+  # it does not delete the file — an excluded path is never treated as an orphan,
+  # so the existing SECURITY.md stays exactly as it is and simply stops being
+  # overwritten on each sync.
+  - SECURITY.md
+

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Repo-specific *tasks* go in a `rhiza_task.tasks` entry point, repo-specific *targets* in
 # `local.mk`, which core deliberately does not ignore. Nothing goes below the shim: this
 # file is synced, so the next `/rhiza:update` overwrites whatever was appended to it.
-RHIZA_TASK ?= rhiza-task@1.1.0
+RHIZA_TASK ?= rhiza-task@1.3.1
 
 # uv cannot be delegated, because uv is what runs the CLI. Prepended so a machine carrying
 # an older uv still resolves the pin, exported because task bodies shell out to bare `uv`.

--- a/cliff.toml
+++ b/cliff.toml
@@ -64,8 +64,19 @@ sort_commits = "oldest"
 # Group commits into changelog sections. The leading HTML comment controls the
 # section ordering and is stripped from the rendered heading via `striptags`.
 commit_parsers = [
-  # Drop automated noise commits that don't provide user-facing signal.
-  { message = ".*\\[skip ci\\].*", skip = true },
+  # Drop automated noise commits that don't provide user-facing signal -- the machine-written
+  # `Update the compiled paper [skip ci]` kind, which puts the marker in its *subject*.
+  #
+  # Anchored to the subject line, and that is load-bearing rather than tidy. git-cliff matches
+  # this against the whole message, so the unanchored `.*\[skip ci\].*` also dropped any commit
+  # whose *body* merely mentioned the marker -- a commit message quoting the format of another
+  # commit message is enough. That silently ate `feat: give the paper branch a README` (#1626)
+  # out of v1.6.0's notes, for one backticked mention twenty lines down. Same failure as the
+  # `bump` alternative below: a substring search treating a mention as the thing itself.
+  #
+  # `^` with no `(?m)` is start-of-message, and `[^\n]*` cannot cross a newline, so only the
+  # subject can match.
+  { message = "^[^\\n]*\\[skip ci\\]", skip = true },
   # Only the release flow's own commits. A bare `bump` alternative here also ate every
   # `chore(deps): bump <dependency>` — the rhiza-hooks v1.2.0 bump (#1487) vanished from
   # v1.3.2's notes that way, and had been vanishing for a while unnoticed: a Dependabot

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,5 +12,11 @@ nav:
   - Development:
       - Marimo: development/MARIMO.md
       - Tests: development/TESTS.md
-  - Notebooks: notebooks.md
-  - Reports: reports.md
+  - Notebooks:
+      - Balanced: notebooks/Balanced.html
+      - One Asset Fading Out: notebooks/OneAssetFadingOut.html
+      - Monkey: notebooks/monkey.html
+      - Pairs: notebooks/pairs.html
+  - Reports:
+      - Test Report: reports/html-report/report.html
+      - Coverage Report: reports/html-coverage/index.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,13 +101,16 @@ typechecker = "both"
 # package reads paths and writes files, which is exactly what Windows and macOS catch.
 ci-os-matrix = ["ubuntu-latest", "macos-latest", "windows-latest"]
 
+# `.rhiza/.env` said `docs/notebooks`, which IS the CLI default -- but this repo has no such
+# folder; the notebooks live in `book/marimo/notebooks`. The v1.4.2 migration note recorded
+# that as pre-existing and deferred it, on the grounds that the marimo gate merely built an
+# empty matrix and passed. v1.6.0 removed the "and passing" half: `rhiza_book.yml` gained a
+# `book-nav` gate, and `_export_notebooks()` reads this setting, so a folder that is not
+# there means no `notebooks/*.html` is ever exported.
+marimo-folder = "book/marimo/notebooks"
+
 # Not set, on purpose. This list is what stops the next person re-adding them:
 #   source-folder         -- `.rhiza/.env` said `src`, already the CLI default.
-#   marimo-folder         -- `.rhiza/.env` said `docs/notebooks`, which IS the CLI default,
-#                            so this migration changes nothing. Note separately that the
-#                            notebooks actually live in `book/marimo/notebooks`, so the
-#                            marimo gate has been building an empty matrix and passing;
-#                            pre-existing, and a fix belongs in its own PR, not here.
 #   mkdocs-extra-packages -- the deleted Makefile carried only
 #                            `--with 'mkdocstrings[python]'`, which is now the default list.
 #                            Restating it would be worse than omitting it: naming this


### PR DESCRIPTION
Template `jebel-quant/rhiza`: `v1.5.0` → **`v1.6.0`**.

- 33 template files considered, **11 changed** (7 workflow callers, `.pre-commit-config.yaml`, `Makefile`, `cliff.toml`, `.rhiza/template.lock`).
- No conflicts — nothing had to be resolved.
- Nothing left unstaged: the sync touched no repo-owned files.

An unrelated uncommitted edit to `SECURITY.md` (dropping the "Renovate" bullet)
was stashed before this branch was cut, so it is deliberately **not** in this PR.
The sync did not touch `SECURITY.md`, so that edit still applies cleanly on top.

No gates were run — run `/rhiza:quality` for a scorecard.

---

### Also in this PR: `SECURITY.md` is no longer template-owned

`SECURITY.md` moved from the lock's `files:` list into `exclude:`. The template's
copy enumerates security measures generically and the accurate list differs per
repo, so it is maintained here from now on.

Excluding a path does **not** delete it — `clean_orphaned_files` skips excluded
paths ("an excluded path is never an orphan"), and the file is byte-identical
before and after the re-sync. It simply stops being overwritten on each sync.

---

### Also in this PR: the `book-nav` gate

v1.6.0's `rhiza_book.yml` adds a `book-nav` step that fails when a `mkdocs.yml` nav
entry has no page in the built site. It caught **2 of 5** here: `notebooks.md` and
`reports.md`.

Neither has ever existed. They were added to the nav by hand in `5799536` (Apr 2026),
replacing an ADR section, and nothing in the make layer or in rhiza-task has ever
generated a page at either path. The template's own `.gitignore` still lists
`docs/reports.md` — a vestige of an older rhiza that did generate it — so a
hand-written page there would also be invisible to git.

**Fix:** point the two sections at the artifacts the book actually builds, the way
cvxcla and cvxrisk already do, instead of at pages nothing produces.

That in turn needed the notebooks to be exported, and they were not: `marimo-folder`
sat at the default `docs/notebooks`, a folder this repo does not have — the notebooks
live in `book/marimo/notebooks`. `_export_notebooks()` read it, logged
`[WARN] no marimo folder; skipping notebook export`, and moved on. The v1.4.2
migration note recorded this as pre-existing and deferred it because the marimo gate
merely built an empty matrix and passed; `book-nav` removes the "and passing" half.

No Benchmark entry: this repo has no `tests/benchmarks`, so `benchmark` skips and
produces nothing to link.

Verified locally before pushing: `rhiza-task book` exports all four notebooks,
`rhiza-task book-nav` reports all 9 nav targets resolving, and `rhiza-task deps`
still passes now that deptry also scans the notebook folder. `book / build` is green
on CI.
