### PR TITLE
docs: drop the Renovate entry from SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -76,7 +76,6 @@ This project implements several security measures:
 - **SLSA Provenance**: Build attestations for release artifacts (public repositories only)
 - **Locked Dependencies**: `uv.lock` ensures reproducible builds
 - **Dependabot**: Automated dependency updates with security patches (version and security updates)
-- **Renovate**: Additional automated dependency update management
 
 ### Release Security
 - **OIDC Publishing**: PyPI trusted publishing without stored credentials


### PR DESCRIPTION
`SECURITY.md` lists Renovate among this repo's security measures:

```markdown
- **Renovate**: Additional automated dependency update management
```

That is no longer true. Renovate retired itself here on 2026-02-27: #711 — the last
pull request it ever opened — deleted `renovate.json`, and there is no Renovate
configuration anywhere in the tree today (`git ls-files | grep -i renovate` is empty,
and the `check-renovate` pre-commit hook reports `no files to check`). Every
dependency bump since has come from Dependabot, which is configured in
`.github/dependabot.yml` and already has its own bullet on the line above.

So the entry claims a control that isn't running. Removed.

## Not changed here

`README.md` still carries a `Renovate enabled` badge and `web/app.py` still links to
renovatebot.com. Both are stale for the same reason, but they aren't security claims,
so they're left for a separate pass rather than folded into this one.
